### PR TITLE
Ticket18

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,7 +14,8 @@ Changelog
 - Resolved issue where invalid sort parameters broke the querystring tile. Closes issue #42
   [obct537]
 
-- Resolved issue where the images were missing due to the url being wrong. Closes issue #17  [robzonenet]
+- Resolved issue where the images were missing due to the url being wrong. Closes issue #17
+  [robzonenet]
 
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,9 @@ Changelog
 - Resolved issue where invalid sort parameters broke the querystring tile. Closes issue #42
   [obct537]
 
+- Resolved issue where the images were missing due to the url being wrong. Closes issue #17  [robzonenet]
+
+
 
 2.0.29 (2017-04-04)
 -------------------

--- a/castle/cms/profiles/default/actions.xml
+++ b/castle/cms/profiles/default/actions.xml
@@ -328,7 +328,7 @@
    <property name="title">Rules</property>
    <property name="description"></property>
    <property
-      name="url_expr">string:${object/absolute_url}/@@manage-content-rules</property>
+      name="url_expr">string:${plone_context_state/canonical_object_url}/@@manage-content-rules</property>
    <property name="link_target"></property>
    <property name="icon_expr"></property>
    <property

--- a/castle/cms/static/less/logged-in/toolbar.less
+++ b/castle/cms/static/less/logged-in/toolbar.less
@@ -375,7 +375,7 @@ body.castle-toolbar-active.no-roles{
   z-index: 99;
 }
 
-.castle-toolbar-container-top .castle-btn-dropdown-cog span {
+.castle-toolbar-container-top .castle-btn-dropdown-cog button span, .castle-toolbar-container-top .castle-btn-dropdown-cogopened button span {
   position: absolute;
   left: -999em;
 }


### PR DESCRIPTION
This is for ticket 8 not 18. This is for when the user clicks on the cog.  There is a new class name castle-btn-dropdown-cogopened instead of castle-btn-dropdown-cog so the words 'site settings' showed up when clicked