### PR TITLE
Prevent adding duplicate tiles during install

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,11 @@ Changelog
 2.0.33 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Site install now wont add duplicate slot tiles
+  [obct537]
+
+- Original image scale now actually does something
+  [obct537]
 
 
 2.0.32 (2017-04-28)

--- a/castle/cms/install.py
+++ b/castle/cms/install.py
@@ -130,6 +130,12 @@ def tiles(site, req, tiles_data=_tiles_data):
             meta_data = meta_data_manager.get()
 
             existing_tiles = meta_data.get('tiles') or []
+            new_tile_id = tile['meta']['id']
+
+            if new_tile_id in [x['id'] for x in existing_tiles]:
+                # check if the tile we're trying to install is already there.
+                continue
+
             existing_tiles.append(meta)
             meta_data['tiles'] = existing_tiles
             meta_data['mode'] = 'show'

--- a/castle/cms/tiles/image.py
+++ b/castle/cms/tiles/image.py
@@ -28,7 +28,7 @@ def image_scales(context):
     settings = registry.forInterface(IImagingSchema,
                                      prefix="plone",
                                      check=False)
-    values.append(SimpleTerm('', '', 'Original'))
+    values.append(SimpleTerm('original', 'original', 'Original'))
     for allowed_size in settings.allowed_sizes:
         name = allowed_size.split()[0]
         values.append(SimpleTerm(name, name, allowed_size))

--- a/castle/cms/tiles/templates/image.pt
+++ b/castle/cms/tiles/templates/image.pt
@@ -9,7 +9,9 @@
     <a href="${link}" tal:omit-tag="not: link"
        tal:condition="python: dt in ('natural', 'fullwidth')">
       <img src="${image/absolute_url}/@@images/image/${scale}"
-           alt="${image/Description}" />
+           alt="${image/Description}" tal:condition="python: scale not in ('original')" />
+      <img src="${image/absolute_url}/@@images/image"
+        alt="${image/Description}" tal:condition="python: scale in ('original')"/>
     </a>
     <a href="${link}" tal:omit-tag="not: link"
        tal:condition="python: dt not in ('natural', 'fullwidth')">


### PR DESCRIPTION
If the castle gets re-ran, don't re-add slot tiles if they're already there.
Also fixes an issue with the Original scale  in image tiles.