### PR TITLE
Accessibility: added title to download link

### DIFF
--- a/castle/cms/tiles/templates/audio.pt
+++ b/castle/cms/tiles/templates/audio.pt
@@ -19,7 +19,7 @@
     </tal:desc>
     <p class="transcript"
         tal:condition="python: 'transcript' in df">
-      <a href="${audio/absolute_url}/view">Transcript | Download</a>
+      <a href="${audio/absolute_url}/view">Transcript | Download <span class="hidden">${audio/Title}</span></a>
     </p>
   </div>
 </tal:audio>


### PR DESCRIPTION
added title to download link to meet accessibility standard:

Non-distinguishable links
 2.4.4 Link Purpose (In Context)

The same link text is used for links going to different destinations. Users might not know the difference if they are not somehow explained.


If the destination page is the same, this is not an issue.

If the destination pages are not the same, make sure the links can be distinguished by their link texts or WAI-ARIA labels ('aria-labelledby' or 'aria-label') alone to make the difference clear to all users.