### PR TITLE
(Firefox) show what is in the label attribute in a option tag

### DIFF
--- a/castle/cms/profiles/2_1_2/registry/mosaic.xml
+++ b/castle/cms/profiles/2_1_2/registry/mosaic.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+    <record name="plone.app.mosaic.default_available_actions">
+      <element>tile-background-no-margin</element>
+    </record>
+  <records interface="plone.app.mosaic.interfaces.IFormat"
+           prefix="plone.app.mosaic.formats.tile_background_no_margin">
+    <value key="name">tile-background-no-margin</value>
+    <value key="category">tile</value>
+    <value key="label">Background No Margin</value>
+    <value key="action">tile-toggle-class</value>
+    <value key="icon">true</value>
+    <value key="favorite">false</value>
+    <value key="weight">2</value>
+  </records>
+
+  <records interface="plone.app.mosaic.interfaces.IFormat"
+           prefix="plone.app.mosaic.formats.tile_background_rounded">
+    <value key="name">tile-background-rounded</value>
+    <value key="category">tile</value>
+    <value key="label">Background with rounded corners</value>
+    <value key="action">tile-toggle-class</value>
+    <value key="icon">true</value>
+    <value key="favorite">false</value>
+    <value key="weight">3</value>
+  </records>
+</registry>

--- a/castle/cms/profiles/default/registry/mosaic.xml
+++ b/castle/cms/profiles/default/registry/mosaic.xml
@@ -96,6 +96,7 @@
       <element>insert</element>
       <element>remove</element>
       <element>tile-background</element>
+      <element>tile-background-no-margin</element>
       <element>tile-background-rounded</element>
       <element>tile-padding-bottom</element>
       <element>tile-padding-top</element>
@@ -431,6 +432,17 @@
   </records>
 
   <records interface="plone.app.mosaic.interfaces.IFormat"
+           prefix="plone.app.mosaic.formats.tile_background_no_margin">
+    <value key="name">tile-background-no-margin</value>
+    <value key="category">tile</value>
+    <value key="label">Background No Margin</value>
+    <value key="action">tile-toggle-class</value>
+    <value key="icon">true</value>
+    <value key="favorite">false</value>
+    <value key="weight">2</value>
+  </records>
+
+  <records interface="plone.app.mosaic.interfaces.IFormat"
            prefix="plone.app.mosaic.formats.tile_background_rounded">
     <value key="name">tile-background-rounded</value>
     <value key="category">tile</value>
@@ -438,7 +450,7 @@
     <value key="action">tile-toggle-class</value>
     <value key="icon">true</value>
     <value key="favorite">false</value>
-    <value key="weight">2</value>
+    <value key="weight">3</value>
   </records>
 
   <records interface="plone.app.mosaic.interfaces.IFormat"

--- a/castle/cms/static/less/public/tiles.less
+++ b/castle/cms/static/less/public/tiles.less
@@ -66,13 +66,17 @@ h3.highlight{
 
 /* mosaic formats */
 .mosaic-tile-background,
-.mosaic-tile-background-rounded{
+.mosaic-tile-background-rounded,
+.mosaic-tile-background-no-margin{
   background-color: #EBF0F5;
   margin-bottom: 20px;
   padding: 20px;
   h2,h3,h4{
     border-bottom: 1px solid #dddddd;
   }
+}
+.mosaic-tile-background-no-margin {
+  margin: 0px;
 }
 .mosaic-tile-background-rounded{
   padding: 15px;

--- a/castle/cms/static/patterns/mapselect.js
+++ b/castle/cms/static/patterns/mapselect.js
@@ -29,7 +29,6 @@ define([
           color_keys.map(function(name) {
             var color = colorList[name];
             return D.option({
-              label: name,
               value: color }, name);
           })
         ])

--- a/castle/cms/static/patterns/mapselect.js
+++ b/castle/cms/static/patterns/mapselect.js
@@ -30,8 +30,7 @@ define([
             var color = colorList[name];
             return D.option({
               label: name,
-              value: color
-            });
+              value: color }, name);
           })
         ])
     ];

--- a/castle/cms/upgrades/configure.zcml
+++ b/castle/cms/upgrades/configure.zcml
@@ -76,6 +76,13 @@
       handler=".upgrade_2_1_1.upgrade"
       profile="castle.cms:default"/>
 
+  <genericsetup:registerProfile
+      name="2_1_2"
+      title="CastleCMS upgrade to 2.1.2 profile"
+      directory="../profiles/2_1_2"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
   <genericsetup:upgradeStep
       title="Upgrade Castle to 2.1.2"
       description=""

--- a/castle/cms/upgrades/upgrade_2_1_2.py
+++ b/castle/cms/upgrades/upgrade_2_1_2.py
@@ -1,0 +1,13 @@
+from plone import api
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
+
+
+PROFILE_ID = 'profile-castle.cms.upgrades:2_1_2'
+
+
+def upgrade(context, logger=None):
+    setup = getToolByName(context, 'portal_setup')
+    setup.runAllImportStepsFromProfile('profile-Products.PloneKeywordManager:default')
+    setup.runAllImportStepsFromProfile(PROFILE_ID)
+    cookWhenChangingSettings(api.portal.get())


### PR DESCRIPTION
Firefox won't show what is in the label attribute in a option tag. Because of this map creation wouldn't show the colors to choose from. So the best course of action is to make it part of the content. Also in this commit is an option to have a background color in mosaic content to not have a margin bottom so it looks like 2 or more stack items belong together

The css will probably need compiled. 

Since there is change to mosaic.xml in the default profiles this will probably have to have a upgrade step before release due to making a current castle site see the changes.