### PR TITLE
better way to enforce backend editing url

### DIFF
--- a/castle/cms/__init__.py
+++ b/castle/cms/__init__.py
@@ -1,4 +1,6 @@
+from zope.i18nmessageid import MessageFactory
 
+_ = MessageFactory('castle.cms')
 
 def initialize(context):
     """Initializer called when used as a Zope 2 product."""

--- a/castle/cms/browser/templates/secure-login.pt
+++ b/castle/cms/browser/templates/secure-login.pt
@@ -8,8 +8,10 @@
   </head>
   <body
       tal:define="utils context/@@castle-utils;
-                  backend_urls python:context.portal_registry['plone.backend_url'];
-                  only_allow_login_to_backend_urls python:context.portal_registry['plone.only_allow_login_to_backend_urls'];
+                  site_login python: hasattr(context,'portal_registry');
+                  portreg python: context.portal_registry if site_login else {'plone.backend_url':[],'plone.only_allow_login_to_backend_urls':False};
+                  backend_urls python:portreg['plone.backend_url'];
+                  only_allow_login_to_backend_urls python:portreg['plone.only_allow_login_to_backend_urls'];
                   bad_domain python: only_allow_login_to_backend_urls and backend_urls is not None and portal_url.rstrip('/') not in backend_urls;"
       class="secure-login-template">
 

--- a/castle/cms/browser/templates/secure-login.pt
+++ b/castle/cms/browser/templates/secure-login.pt
@@ -6,7 +6,12 @@
           rel="stylesheet" type="text/css">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   </head>
-  <body tal:define="utils context/@@castle-utils;" class="secure-login-template">
+  <body
+      tal:define="utils context/@@castle-utils;
+                  backend_urls python:context.portal_registry['plone.backend_url'];
+                  only_allow_login_to_backend_urls python:context.portal_registry['plone.only_allow_login_to_backend_urls'];
+                  bad_domain python: only_allow_login_to_backend_urls and backend_urls is not None and portal_url.rstrip('/') not in backend_urls;"
+      class="secure-login-template">
 
     <div id="visual-wrapper">
       <div class="castle-login-header">
@@ -25,7 +30,11 @@
         </div>
       </div>
 
-      <div id="secure-login" data-options="${view/options}" />
+      <div id="secure-login" data-options="${view/options}">
+        <p tal:condition="bad_domain" i18n:translate="description_bad_login_domain" class="login-exception-container">
+            You are attempting to log into this site from the wrong domain; contact your site administrator for assistance.
+        </p>
+      </div>
 
 
 
@@ -52,7 +61,9 @@
         return;
       });
     </script>
-    <script src="${portal_url|nothing}/++plone++castle/components/secure-login.js?v=4">
+
+    <script tal:condition="not:bad_domain" src="${portal_url|nothing}/++plone++castle/components/secure-login.js?v=4">
+
     </script>
   </body>
 </html>

--- a/castle/cms/interfaces/controlpanel.py
+++ b/castle/cms/interfaces/controlpanel.py
@@ -148,15 +148,17 @@ class ISecuritySchema(controlpanel.ISecuritySchema):
         default=None,
         required=False)
 
-    backend_url = schema.TextLine(
-        title=u'Backend site URL',
-        description=u'The URL from which you will be editing and maintaining site content.',
-        default=None,
+    backend_url = schema.Tuple(
+        title=u'Backend site URLs',
+        description=u'The URL(s) from which you will be editing and maintaining site content. '
+                    u'One per URL per line. Main URL first.',
+        value_type=schema.TextLine(),
+        default=(),
         required=False)
 
-    disallow_login_to_public_url = schema.Bool(
-        title=u'Disallow login at public URL',
-        description=u'If set, will prevent logins at the site''s public URL',
+    only_allow_login_to_backend_urls = schema.Bool(
+        title=u'Only allow login at a backend URL',
+        description=u'If set, users can only log in if visiting from a backend URL.',
         default=False,
         required=False)
 

--- a/castle/cms/shield.py
+++ b/castle/cms/shield.py
@@ -37,9 +37,9 @@ def protect(req):
         protect = True
     elif setting == SHIELD.BACKEND:
         backend_url = (registry and
-                       registry.get('plone.backend_url', SHIELD.NONE) or
-                       '')
-        if backend_url.startswith(req.SERVER_URL):
+                       registry.get('plone.backend_url', []) or
+                       [])
+        if req.SERVER_URL in backend_url:
             protect = True
     if protect and api.user.is_anonymous():
         raise Redirect('{}/@@secure-login'.format(

--- a/castle/cms/skins/castle/login_form.cpt
+++ b/castle/cms/skins/castle/login_form.cpt
@@ -13,12 +13,18 @@
  <metal:javascript fill-slot="javascript_head_slot">
    <link href="${portal_url}/++plone++castle/less/misc/secure-login.css?v=3"
          rel="stylesheet" type="text/css">
- <script src="${portal_url}/++plone++castle/components/secure-login.js?v=3">
+ <script tal:define="backend_urls python:context.portal_registry['plone.backend_url'];
+                     only_allow_login_to_backend_urls python:context.portal_registry['plone.only_allow_login_to_backend_urls'];
+                     bad_domain python: only_allow_login_to_backend_urls and backend_urls is not None and portal_url.rstrip('/') not in backend_urls;"
+         tal:condition="not:bad_domain"
+         src="${portal_url}/++plone++castle/components/secure-login.js?v=404">
  </script>
  </metal:javascript>
 </head>
 
-<body>
+<body tal:define="backend_urls python:context.portal_registry['plone.backend_url'];
+                  only_allow_login_to_backend_urls python:context.portal_registry['plone.only_allow_login_to_backend_urls'];
+                  bad_domain python: only_allow_login_to_backend_urls and backend_urls is not None and portal_url.rstrip('/') not in backend_urls;">
     <metal:main fill-slot="main">
 
     <div id="content-core">
@@ -54,42 +60,31 @@
                         target request/target|nothing;
                         target python:test(target in ('_parent', '_top', '_blank', '_self'), target, None);
                         ztu modules/ZTUtils;
-                        login nocall: context/@@secure-login;
-                        backend_urls python:context.portal_registry['plone.backend_url'];
-                        only_allow_login_to_backend_urls python:context.portal_registry['plone.only_allow_login_to_backend_urls'];
-                        bad_domain python: only_allow_login_to_backend_urls and backend_urls is not None and portal_url.rstrip('/') not in backend_urls;">
+                        login nocall: context/@@secure-login">
 
-            <div tal:condition="not: bad_domain">
 
-                <div id="secure-login" data-options="${login/options}">
-                </div>
-
-                <div id="login-new-user"
-                   tal:condition="python:join_url and use_normal">
-                    <strong i18n:translate="heading_new_user">
-                    New user?
-                    </strong>
-
-                    <p i18n:translate="description_no_account">
-                    If you do not have an account here, head over to the
-                    <span i18n:name="registration_form">
-                        <a href=""
-                           tal:define="join_url python:test(came_from, join_url+test(join_url.find('?')==-1, '?', '&amp;')+ztu.make_query(came_from=came_from), join_url);"
-                           tal:attributes="href join_url; target target;"
-                           i18n:translate="description_no_account_registration_linktext"
-                            >registration form</a></span>.
-                    </p>
-
-                </div>
+            <div id="secure-login" data-options="${login/options}">
+                <p i18n:translate="description_bad_login_domain" class="login-exception-container">
+                    You are attempting to log into this site from the wrong domain; contact your site administrator for assistance.
+                </p>
             </div>
 
-            <div tal:condition="bad_domain">
-                <strong i18n:translate="heading_bad_login_domain">
-                    Incorrect login domain
+            <div id="login-new-user"
+               tal:condition="python:join_url and use_normal">
+                <strong i18n:translate="heading_new_user">
+                New user?
                 </strong>
-                <p i18n:translate="description_bad_login_domain">
-                You are attempting to log into this site from the wrong domain; contact your site administrator for assistance.
+
+                <p tal:condition="bad_domain" i18n:translate="description_no_account">
+                If you do not have an account here, head over to the
+                <span i18n:name="registration_form">
+                    <a href=""
+                       tal:define="join_url python:test(came_from, join_url+test(join_url.find('?')==-1, '?', '&amp;')+ztu.make_query(came_from=came_from), join_url);"
+                       tal:attributes="href join_url; target target;"
+                       i18n:translate="description_no_account_registration_linktext"
+                        >registration form</a></span>.
                 </p>
+
             </div>
 
         </metal:login>

--- a/castle/cms/skins/castle/login_form.cpt
+++ b/castle/cms/skins/castle/login_form.cpt
@@ -55,9 +55,9 @@
                         target python:test(target in ('_parent', '_top', '_blank', '_self'), target, None);
                         ztu modules/ZTUtils;
                         login nocall: context/@@secure-login;
-                        public_url python:context.portal_registry['plone.public_url'];
-                        disallow_login_to_public_url python:context.portal_registry['plone.disallow_login_to_public_url'];
-                        bad_domain python: disallow_login_to_public_url and public_url is not None and public_url.strip() != '' and portal_url.rstrip('/') == public_url.strip().rstrip('/');">
+                        backend_urls python:context.portal_registry['plone.backend_url'];
+                        only_allow_login_to_backend_urls python:context.portal_registry['plone.only_allow_login_to_backend_urls'];
+                        bad_domain python: only_allow_login_to_backend_urls and backend_urls is not None and portal_url.rstrip('/') not in backend_urls;">
 
             <div tal:condition="not: bad_domain">
 

--- a/castle/cms/utils.py
+++ b/castle/cms/utils.py
@@ -485,9 +485,9 @@ def get_ip(req):
 def get_backend_url():
     registry = getUtility(IRegistry)
     backend_url = registry.get('plone.backend_url', None)
-    if not backend_url:
+    if not backend_url or len(backend_url) == 0:
         backend_url = api.portal.get().absolute_url()
-    return backend_url
+    return backend_url[0]
 
 
 def parse_query_from_data(data, context=None):


### PR DESCRIPTION
- Changed setting to only allow backend URLs instead of only rejecting logins on public URLS. This was mainly done because it's far too easy to forget a public URL, allowing public users to log in if accessing the site from one of these forgetten URLs. If a backend URL is forgetten, a legit user will be notified and can request it be added. No harm done.
- backend URL fiend can now take multiple URLs.
- `@@secure-login` no longer shows login screen on non-backend URLs.
- Check if bad domain is also done on the server side.