### PR TITLE
cs/cas-218 Hide description content type fields on view

### DIFF
--- a/castle/cms/jbot_overrides/plone.app.z3cform.templates.widget.pt
+++ b/castle/cms/jbot_overrides/plone.app.z3cform.templates.widget.pt
@@ -1,0 +1,40 @@
+<div
+   metal:define-macro="widget-wrapper"
+   i18n:domain="plone"
+   tal:define="widget nocall:context;
+               hidden python:widget.mode == 'hidden';
+               error widget/error;
+               error_class python:error and ' error' or '';
+               empty_values python: (None, '', [], ('', '', '', '00', '00', ''), ('', '', ''));
+               empty_class python: (widget.value in empty_values) and ' empty' or '';
+               fieldname_class string:kssattr-fieldname-${widget/name};"
+   data-pat-inlinevalidation='{"type":"z3c.form"}'
+   tal:attributes="class string:field pat-inlinevalidation ${fieldname_class}${error_class}${empty_class};
+                   data-fieldname widget/name;
+                   id string:formfield-${widget/id};">
+    <label for="" class="horizontal"
+        tal:attributes="for widget/id"
+        tal:condition="not:hidden">
+        <span i18n:translate="" tal:replace="widget/label">label</span>
+
+        <span class="required horizontal" title="Required"
+              tal:condition="python:widget.required and widget.mode == 'input'"
+              i18n:attributes="title title_required;">&nbsp;</span>
+
+        <span class="formHelp"
+            tal:define="description widget/field/description"
+            i18n:translate=""
+            tal:content="structure description"
+            tal:condition="python:description and not hidden"
+            >field description
+        </span>
+    </label>
+
+    <div class="fieldErrorBox"
+        tal:content="structure error/render|nothing">
+        Error
+    </div>
+
+    <input type="text" tal:replace="structure widget/render"
+           metal:define-slot="widget" />
+</div>

--- a/castle/cms/jbot_overrides/plone.app.z3cform.templates.widget.pt
+++ b/castle/cms/jbot_overrides/plone.app.z3cform.templates.widget.pt
@@ -25,7 +25,8 @@
             tal:define="description widget/field/description"
             i18n:translate=""
             tal:content="structure description"
-            tal:condition="python:description and not hidden"
+            tal:condition="python:description and not hidden and
+                           context.request.URL.split('/')[-1] == '@@edit'"
             >field description
         </span>
     </label>


### PR DESCRIPTION
You know, like you got your content type and it's got fields with descriptions... There's no reason to show the field descriptions on the view. But it _does_ makes sense to show it when editing content. [This](https://github.com/castlecms/castle.cms/commit/97b2b4251688503c7adb84ea06a462f4eb37e452) is what I changed.