### PR TITLE
Show descriptions in field editor

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ Changelog
 2.0.46 (unreleased)
 -------------------
 
+- Hide field descriptions for custom content type views
+  [CorySanin]
+
 - add info and warnings for missing REDIS_SERVER env var
   [tkimnguyen]
 

--- a/castle/cms/jbot_overrides/plone.app.z3cform.templates.widget.pt
+++ b/castle/cms/jbot_overrides/plone.app.z3cform.templates.widget.pt
@@ -26,7 +26,7 @@
             i18n:translate=""
             tal:content="structure description"
             tal:condition="python:description and not hidden and
-                           context.request.URL.split('/')[-1] == '@@edit'"
+                           context.request.URL.split('/')[-1] in ('@@edit', '@@fields')"
             >field description
         </span>
     </label>


### PR DESCRIPTION
A change made by someone (I wonder who 😂) unintentionally hid field descriptions on the @@fields page. It would be better if it could blacklist the one view that they shouldn't appear on as opposed to whitelisting all the ones it's supposed to appear on.