### PR TITLE
Support for Subject:list search parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ Changelog
 2.1 (unreleased)
 ----------------
 
+- Add support for the Subject:list search parameter
+  [CorySanin]
+
 - Add password expiration option with whitelist
   [CorySanin]
 

--- a/castle/cms/browser/search.py
+++ b/castle/cms/browser/search.py
@@ -132,6 +132,7 @@ _search_attributes = [
     'Title',
     'Description',
     'Subject',
+    'Subject:list',
     'contentType',
     'created',
     'modified',
@@ -145,7 +146,8 @@ _search_attributes = [
 _valid_params = [
     'SearchableText',
     'portal_type',
-    'Subject'
+    'Subject',
+    'Subject:list'
 ]
 
 

--- a/castle/cms/static/components/search.js
+++ b/castle/cms/static/components/search.js
@@ -100,11 +100,15 @@ require([
       if(that.props.Subject){
         state.Subject = that.props.Subject;
       }
+      if(that.props['Subject:list']){
+        state['Subject:list'] = that.props['Subject:list'];
+      }
       $.ajax({
         url: this.props.searchUrl,
         data: state
       }).done(function(data){
         that.props.Subject = undefined;
+        that.props['Subject:list'] = undefined;
         that.setState({
           results: data.results,
           count: data.count,
@@ -425,7 +429,7 @@ require([
     }
   });
 
-  var page = 1, searchType = 'all', Subject;
+  var page = 1, searchType = 'all', Subject, Subjectlist;
   var searchSite = false;
   try{
     page = parseInt(getParameterByName('page'));
@@ -436,6 +440,9 @@ require([
   try{
     Subject = getParameterByName('Subject');
   }catch(e){}
+  try{
+    Subjectlist = getParameterByName(encodeURIComponent('Subject:list'));
+  }catch(e){}
 
   try{
     searchSite = getParameterByName('searchSite');
@@ -445,6 +452,7 @@ require([
   var component = R.render(R.createElement(SearchComponent, cutils.extend(JSON.parse(el.getAttribute('data-search')), {
     SearchableText: getParameterByName('SearchableText') || '',
     Subject: Subject,
+    'Subject:list': Subjectlist,
     searchUrl: el.getAttribute('data-search-url'),
     searchType: searchType,
     page: page,


### PR DESCRIPTION
Fixes a bug that ignores the `Subject:list` parameter when doing a search.