### PR TITLE
Fix change password on login

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix change password on login
+  [CorySanin]
 
 
 2.1.1 (2018-10-02)

--- a/castle/cms/browser/login.py
+++ b/castle/cms/browser/login.py
@@ -234,7 +234,7 @@ The user requesting this access logged this information:
                 bad_domain = only_allow_login_to_backend_urls and \
                              len(backend_urls) > 0 and \
                              portal_url.rstrip('/') not in backend_urls and \
-                             portal_url.rstrip('/')+'/' not in backend_urls
+                             portal_url.rstrip('/') + '/' not in backend_urls
                 if bad_domain:
                     return json.dumps({
                         'success': False,

--- a/castle/cms/static/components/secure-login.js
+++ b/castle/cms/static/components/secure-login.js
@@ -167,7 +167,8 @@ require([
       var that = this;
       e.preventDefault();
       that.api({
-        existing_password: that.state.password1,
+        username: that.state.username,
+        existing_password: that.state.existing_password,
         new_password: that.state.new_password1,
         _authenticator: that.state.authenticator,
         apiMethod: 'set_password'
@@ -368,6 +369,7 @@ require([
           D.label({ htmlFor: 'password1' + that.state.counter}, 'Existing password'),
           D.input({type: 'password', value: that.state.password1,
                    disabled: that.state.state !== STATES.CHANGE_PASSWORD,
+                   onChange: that.pwChangeValueChanged.bind(that, 'existing_password'),
                    className: 'form-control', id: 'password1' + that.state.counter})
         ]),
         D.div({ className: 'form-group'}, [


### PR DESCRIPTION
Existing password wasn't being sent to the server and wouldn't authenticate the user in order to change the password. Not related to password reset form.