### PR TITLE
cs/cas-386 Save default values for fields of a Dexterity type without showing an error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
+- Fix saving default values for Dexterity fields
+  [CorySanin]
+
 - Handle potential errors caused by invalid references in folder ordering.
   See https://github.com/plone/plone.folder/pull/10 for details
   [vangheem]

--- a/castle/cms/browser/fields.py
+++ b/castle/cms/browser/fields.py
@@ -2,7 +2,28 @@
 import pkg_resources
 
 from plone.app.dexterity.browser import fields
-from plone.app.dexterity.browser.fields import EnhancedSchemaListing
+from plone.schemaeditor.browser.schema.listing import ReadOnlySchemaListing
+from zope.event import notify
+from z3c.form.events import DataExtractedEvent
+
+
+class EnhancedSchemaListing(fields.EnhancedSchemaListing):
+    def extractData(self, setErrors=True):
+        data, errors = super(EnhancedSchemaListing, self).extractData(setErrors=setErrors)
+        for group in self.groups:
+            groupData, groupErrors = group.extractData(setErrors=setErrors)
+            data.update(groupData)
+            if groupErrors:
+                if errors:
+                    errors += groupErrors
+                else:
+                    errors = groupErrors
+        for fname, value in data.items():
+            if fname not in self.context.schema:
+                del data[fname]
+        notify(DataExtractedEvent(data, errors, self))
+        return data, errors
+
 
 if pkg_resources.get_distribution('plone.resourceeditor'):
     advancedbtns = EnhancedSchemaListing.buttons.copy()
@@ -17,3 +38,10 @@ class TypeFieldsPage(fields.TypeFieldsPage):
                 EnhancedSchemaListing.buttons = advancedbtns
             else:
                 EnhancedSchemaListing.buttons = regularbtns
+
+    @property
+    def form(self):
+        if self.context.fti.hasDynamicSchema:
+            return EnhancedSchemaListing
+        else:
+            return ReadOnlySchemaListing


### PR DESCRIPTION
Kim mentioned maybe including a fix for this in Plone 5.0.9. If we go that route, this PR isn't necessary.