### PR TITLE
Do not redirect to `/not-found`, just directly render not found template

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
+- Do not redirect to `/not-found`, just directly render not found template
+  [vangheem]
+
 - Adding basic Robot testing setup
   [obct537]
 

--- a/castle/cms/browser/configure.zcml
+++ b/castle/cms/browser/configure.zcml
@@ -412,14 +412,6 @@
     template="templates/fourohfour.pt"
     layer="..interfaces.ICastleLayer"
     />
-  <browser:page
-    for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
-    class=".fourohfour.NotFoundView"
-    name="not-found"
-    permission="zope2.View"
-    template="templates/fourohfour.pt"
-    layer="..interfaces.ICastleLayer"
-    />
 
   <browser:page
     for="zope.interface.common.interfaces.IException"

--- a/castle/cms/browser/fourohfour.py
+++ b/castle/cms/browser/fourohfour.py
@@ -15,6 +15,11 @@ from six.moves.urllib.parse import unquote
 class FourOhFour(FourOhFourView):
 
     def __call__(self):
+        shield.protect(self.request)
+        if '++' in self.request.URL:
+            self.request.response.setStatus(404)
+            return self.index()
+
         self.notfound = self.context
         self.context = api.portal.get()
         archive_storage = archival.Storage(self.context)
@@ -47,7 +52,8 @@ class FourOhFour(FourOhFourView):
 
         self.attempt_redirect()
 
-        raise Redirect('{}/not-found'.format(api.portal.get().absolute_url()))
+        self.request.response.setStatus(404)
+        return self.index()
 
     def attempt_redirect(self):
         url = self._url()
@@ -108,11 +114,3 @@ class FourOhFour(FourOhFourView):
             url += "?" + query_string
         raise Redirect(url)
         return True
-
-
-class NotFoundView(BrowserView):
-
-    def __call__(self):
-        shield.protect(self.request)
-        self.request.response.setStatus(404)
-        return self.index()

--- a/castle/cms/cache.py
+++ b/castle/cms/cache.py
@@ -72,21 +72,26 @@ class RedisAdapter(AbstractDict):
 def get_client(fun_name=''):
     server = os.environ.get('REDIS_SERVER', None)
     if server is None:
-        logger.warn(
+        if not getattr(get_client, '___default_warned', True):
+            logger.warning("unable to connect to redis")
+            get_client.___default_warned = False
+        logger.warning(
             "Not using redis; REDIS_SERVER environment variable is undefined")
         return base_choose_cache(fun_name)
 
     client = getattr(thread_local, "client", None)
     if client is None:
         server = os.environ.get("REDIS_SERVER", "127.0.0.1:6379")
-        logger.info("using REDIS_SERVER %s" % server)
+        logger.debug("using REDIS_SERVER %s" % server)
         host, port = server.split(':')
         client = redis.StrictRedis(host=host, port=int(port), db=0)
         try:
             client.get('test-key')
             thread_local.client = client
         except redis.exceptions.ConnectionError:
-            logger.warn("unable to connect to redis")
+            if not getattr(get_client, '___connect_warned', True):
+                logger.warning("unable to connect to redis")
+                get_client.___connect_warned = False
             return base_choose_cache(fun_name)
     return RedisAdapter(client, fun_name)
 


### PR DESCRIPTION
Also disable some noise on logging...