### PR TITLE
Fix 2.0.41 upgrade step that cleared `slot_tiles` setting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,12 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Fixes:
+
+- Fix 2.0.41 upgrade step that cleared `slot_tiles` setting and
+  attempt to fix missing `slot_tiles` on sites that have been
+  upgraded since.
+  [vangheem]
 
 
 2.3.1 (2018-12-04)

--- a/castle/cms/profiles/2_0_41/registry/castle.xml
+++ b/castle/cms/profiles/2_0_41/registry/castle.xml
@@ -2,8 +2,10 @@
 <registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
           i18n:domain="plone">
   <record name="castle.slot_tiles">
-    <element key="advanced">
-      <element>castle.cms.survey</element>
-    </element>
+    <value purge="false">
+      <element key="Advanced" purge="false">
+        <element>castle.cms.survey</element>
+      </element>
+    </value>
   </record>
 </registry>

--- a/castle/cms/profiles/default/metadata.xml
+++ b/castle/cms/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2301</version>
+  <version>2302</version>
   <dependencies>
     <dependency>profile-plone.app.querystring:default</dependency>
     <dependency>profile-plone.app.mosaic:default</dependency>

--- a/castle/cms/upgrades/configure.zcml
+++ b/castle/cms/upgrades/configure.zcml
@@ -121,4 +121,12 @@
       handler=".upgrade_2_3_1.upgrade"
       profile="castle.cms:default" />
 
+  <genericsetup:upgradeStep
+      title="Upgrade CastleCMS to 2.3.2"
+      description=""
+      source="*"
+      destination="2302"
+      handler=".upgrade_2_3_2.upgrade"
+      profile="castle.cms:default" />
+
 </configure>

--- a/castle/cms/upgrades/upgrade_2_3_1.py
+++ b/castle/cms/upgrades/upgrade_2_3_1.py
@@ -1,39 +1,9 @@
 from plone import api
-from zope.component import getUtility
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 
 
 PROFILE_ID = 'profile-castle.cms.upgrades:2_3_1'
-
-_recover_slot_tiles = {
-    "Media": [
-        "castle.cms.audiotile",
-        "castle.cms.embedtile",
-        "castle.cms.maptile",
-        "castle.cms.gallerytile",
-        "castle.cms.slidertile",
-        "castle.cms.videotile",
-        "castle.cms.imagetile"
-    ],
-    "Social": [
-        "castle.cms.facebookPage",
-        "castle.cms.pin",
-        "castle.cms.twitterTimeline",
-        "castle.cms.tweet",
-        "castle.cms.sharing"
-    ],
-    "Advanced": [
-        "castle.cms.fragment",
-        "castle.cms.calendar",
-        "castle.cms.survey",
-        "castle.cms.querylisting",
-        "plone.app.standardtiles.contentlisting",
-        "castle.cms.navigation",
-        "castle.cms.search"
-    ]
-}
 
 
 def upgrade(context, logger=None):
@@ -46,12 +16,3 @@ def upgrade(context, logger=None):
         'plone.app.registry',
         run_dependencies=False,
     )
-
-    registry = getUtility(IRegistry)
-    tiles = registry['castle.slot_tiles']
-    for recover_type, recover_tiles in _recover_slot_tiles.items():
-        if recover_type not in tiles:
-            tiles[recover_type] = []
-        for tile_id in recover_tiles:
-            if tile_id not in tiles[recover_type]:
-                tiles[recover_type].append(tile_id)

--- a/castle/cms/upgrades/upgrade_2_3_2.py
+++ b/castle/cms/upgrades/upgrade_2_3_2.py
@@ -1,11 +1,6 @@
-from plone import api
 from zope.component import getUtility
 from plone.registry.interfaces import IRegistry
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
 
-
-PROFILE_ID = 'profile-castle.cms.upgrades:2_3_1'
 
 _recover_slot_tiles = {
     "Media": [
@@ -37,16 +32,6 @@ _recover_slot_tiles = {
 
 
 def upgrade(context, logger=None):
-    setup = getToolByName(context, 'portal_setup')
-    setup.runAllImportStepsFromProfile(PROFILE_ID)
-    cookWhenChangingSettings(api.portal.get())
-
-    setup.runImportStepFromProfile(
-        'profile-collective.elasticsearch:default',
-        'plone.app.registry',
-        run_dependencies=False,
-    )
-
     registry = getUtility(IRegistry)
     tiles = registry['castle.slot_tiles']
     for recover_type, recover_tiles in _recover_slot_tiles.items():


### PR DESCRIPTION
- everything that had been upgraded between 2.0.41 and 2.3.1 is broken
- tries to fix sites that were broken but we don't know what they user might have modified manually... Unlikely though.