### PR TITLE
Fix duplicate `<head>` tags showing up

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,9 @@ Changes:
 
 Fixes:
 
+- Fix duplicate `<head>` tags showing up
+  [vangheem]
+
 - Upgrade mosaic to fix layout selection styles
   [vangheem]
 


### PR DESCRIPTION
We were using `html.fromstring` which automatically adds `<html><head></head></html>` tags around content. So doing `replace_with_children` wouldn't really work with it correctly.

This should also improve performance.