### PR TITLE
WIP #231 News Item lead image 

### DIFF
--- a/castle/cms/static/patterns/edittile.js
+++ b/castle/cms/static/patterns/edittile.js
@@ -1,5 +1,9 @@
 /* global define */
 
+$(document).ready(function() {
+  document.getElementById("formfield-form-widgets-ILeadImage-image").firstElementChild.firstElementChild.innerText = "When in use, click edit button on the lead image tile area";
+});
+
 define([
   'jquery',
   'pat-base',


### PR DESCRIPTION
add javascript description for lead image that when actively used on a page it will not display in edit properties and if not actively used will display back on edit properties

note - the lead image behavior is a Plone default with any content type just that News Item has lead image on the layout