### PR TITLE
#476 add links when deleting to and restoring from recycle bin

### DIFF
--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -7,6 +7,7 @@ from castle.cms import tasks
 from castle.cms import trash
 from castle.cms.utils import get_paste_data
 from castle.cms.utils import is_max_paste_items
+from chameleon import PageTemplate
 from OFS.CopySupport import _cb_encode
 from OFS.CopySupport import cookie_path
 from OFS.CopySupport import CopyError
@@ -215,9 +216,7 @@ class TrashActionView(delete.DeleteActionView):
     failure_msg = 'Failed to move items to recycle bin'
 
     def action(self, obj):
-        from chameleon import PageTemplate
         trash.object(obj)
-        import pdb; pdb.set_trace()
         if hasattr(self, 'multiple_items') is False or self.multiple_items is False:
             self.multiple_items = True
             self.success_msg = PageTemplate(self.single_success_msg)
@@ -355,7 +354,6 @@ FC_MINIMAL_LAYOUT = """<!doctype html>
 class FolderContentsView(BaseFolderContentsView):
 
     def __call__(self):
-        import pdb; pdb.set_trace()
         self.request.environ['X-CASTLE-LAYOUT'] = FC_MINIMAL_LAYOUT
         return super(FolderContentsView, self).__call__()
 

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -4,6 +4,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from castle.cms import cache
 from castle.cms import tasks
+from castle.cms import trash
 from castle.cms.utils import get_paste_data
 from castle.cms.utils import is_max_paste_items
 from OFS.CopySupport import _cb_encode

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -206,6 +206,8 @@ when the content is done being deleted."""
 
 
 class TrashActionView(delete.DeleteActionView):
+    failure_msg = 'Failed to move items to recycle bin'
+    
     def message_async(self):
         return self.json({
             'status': 'success',
@@ -219,6 +221,9 @@ class TrashActionView(delete.DeleteActionView):
                 'html': 'Successfully moved items to <a href="./@@trash">Recycle Bin</a>.',
             }
         })
+
+    def action(self, obj):
+        trash.object(obj)
 
     def __call__(self):
         delete.DeleteActionView.__call__(self)  # run the parent class function for this child

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -212,6 +212,8 @@ class TrashActionView(delete.DeleteActionView):
 
     def action(self, obj):
         trash.object(obj)
+        import pdb; pdb.set_trace()
+        self.success_msg = "Successfully moved <a href=\"%s\">%s</a> to recycle bin" % (obj.absolute_url(), obj.Title())
 
 
 @implementer(IStructureAction)

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -206,24 +206,61 @@ when the content is done being deleted."""
         else:
             return self.delete_async(selection, count)
 
+def InjectJS(script):
+    return '<script type="text/javascript">' + script + '</script>'
 
 class TrashActionView(delete.DeleteActionView):
-    single_success_msg = """<p>Successfully moved
-    <span tal:content='obj.Title()'> </span>
-    to recycle bin, located at:
-    <a tal:attributes='href obj.absolute_url()' tal:content='obj.absolute_url()'></p>"""
-    success_msg = 'Successfully moved items to recycle bin'
-    failure_msg = 'Failed to move items to recycle bin'
 
-    def action(self, obj):
-        trash.object(obj)
-        if hasattr(self, 'multiple_items') is False or self.multiple_items is False:
-            self.multiple_items = True
-            self.success_msg = PageTemplate(self.single_success_msg)
-            self.success_msg = PageTemplate.render(self.success_msg, obj=obj)
+    script_injection = InjectJS("""
+// global context script which allows html to be rendered in @fc-trash success messages
+(function($, setTimeout, kvs) {
+    parseResponseHTML = function(restext) {
+        return JSON.parse(restext)['msg']['html'];
+    };
+
+    if(!kvs['trash_html_event_bound']) { // check if we have bound this event already
+        $(document).ajaxSuccess(function(event, xhr, settings) { // bind event to ajaxSuccess
+            if( (settings.url.split('@@fc-trash').length > 1) && (!(settings.data.split('&render=yes').length > 1)) ) { // only run on @@fc-trash AJAX requests where "&render=yes" does not exist in the request data
+                setTimeout(function() {
+                    $('.alert-success').find('span').html(parseResponseHTML(xhr.responseText)); // inject the HTML
+                }, 250); //wait a bit because underscore will render first and then this function will overide it
+            }
+        });
+
+        kvs['trash_html_event_bound'] = true; // prevent this event from being bound to the Global Ajax Event Handler multiple times
+    }
+})(jQuery, window.setTimeout, (function() {
+    // basic object based key value storage -- accessed as "kvs" in the main function above
+    if(typeof window.__ === 'undefined') {
+        window.__ = {};
+    }
+
+    return window.__;
+})());
+    """)
+
+    def message_async(self):
+        return self.json({
+            'status': 'success',
+            'msg': {
+                'label': 'Recycled',
+                'type': 'success',
+                'text': '',
+                'html': 'Successfully moved items to <a href="./@@trash">Recycle Bin</a>.',
+            }
+        })
+
+    def __call__(self):
+        delete.DeleteActionView.__call__(self) # run the parent class function for this child
+
+        # special handling from here on so we can do async handling
+        if self.request.form.get('render') == 'yes':
+            self.request.response.setHeader('Content-Type', 'application/json')
+            return json.dumps({
+                'html': self.script_injection
+            })
         else:
-            self.success_msg = 'Successfully moved items to recycle bin'
-            self.multiple_items = True
+            return self.message_async()
 
 
 @implementer(IStructureAction)

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -4,7 +4,6 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from castle.cms import cache
 from castle.cms import tasks
-from castle.cms import trash
 from castle.cms.utils import get_paste_data
 from castle.cms.utils import is_max_paste_items
 from chameleon import PageTemplate

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -6,7 +6,6 @@ from castle.cms import cache
 from castle.cms import tasks
 from castle.cms.utils import get_paste_data
 from castle.cms.utils import is_max_paste_items
-from chameleon import PageTemplate
 from OFS.CopySupport import _cb_encode
 from OFS.CopySupport import cookie_path
 from OFS.CopySupport import CopyError

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -208,7 +208,7 @@ when the content is done being deleted."""
 
 class TrashActionView(delete.DeleteActionView):
     failure_msg = 'Failed to move items to recycle bin'
-    
+
     def message_async(self):
         return self.json({
             'status': 'success',

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -211,9 +211,14 @@ class TrashActionView(delete.DeleteActionView):
     failure_msg = 'Failed to move items to recycle bin'
 
     def action(self, obj):
+        from chameleon import PageTemplate
         trash.object(obj)
-        import pdb; pdb.set_trace()
-        self.success_msg = "Successfully moved <a href=\"%s\">%s</a> to recycle bin" % (obj.absolute_url(), obj.Title())
+        if not hasattr(self, multiple_items) or self.multiple_items is False:
+            self.multiple_items = True
+            self.success_msg = PageTemplate("Successfully moved <a tal:attributes='href obj.absolute_url()'> tal:attribute='obj.Title()' </a> to recycle bin")
+            self.success_msg = PageTemplate.render(self.success_msg, obj=obj)
+        else:
+            self.success_msg = 'Successfully moved items to recycle bin'
 
 
 @implementer(IStructureAction)

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -207,20 +207,20 @@ when the content is done being deleted."""
 
 
 class TrashActionView(delete.DeleteActionView):
+    single_success_msg = """<p>Successfully moved
+    <span tal:content='obj.Title()'> </span>
+    to recycle bin, located at:
+    <a tal:attributes='href obj.absolute_url()' tal:content='obj.absolute_url()'></p>"""
     success_msg = 'Successfully moved items to recycle bin'
     failure_msg = 'Failed to move items to recycle bin'
 
     def action(self, obj):
         from chameleon import PageTemplate
         trash.object(obj)
-        if not hasattr(self, 'multiple_items') or self.multiple_items == False:
+        import pdb; pdb.set_trace()
+        if hasattr(self, 'multiple_items') is False or self.multiple_items is False:
             self.multiple_items = True
-            self.success_msg = PageTemplate("""<div tal:define="Std modules/Products.PythonScripts/standard;
-                 restructured_text nocall: Std/restructured_text;"
-    tal:content="structure python: restructured_text(context.Description())">
-<p>Successfully moved <a tal:attributes='href obj.absolute_url()' tal:content='obj.Title()' class='link'> </a> to recycle bin</p>
-</div>
-""")
+            self.success_msg = PageTemplate(self.single_success_msg)
             self.success_msg = PageTemplate.render(self.success_msg, obj=obj)
         else:
             self.success_msg = 'Successfully moved items to recycle bin'
@@ -355,6 +355,7 @@ FC_MINIMAL_LAYOUT = """<!doctype html>
 class FolderContentsView(BaseFolderContentsView):
 
     def __call__(self):
+        import pdb; pdb.set_trace()
         self.request.environ['X-CASTLE-LAYOUT'] = FC_MINIMAL_LAYOUT
         return super(FolderContentsView, self).__call__()
 

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -221,7 +221,7 @@ class TrashActionView(delete.DeleteActionView):
         })
 
     def __call__(self):
-        delete.DeleteActionView.__call__(self) # run the parent class function for this child
+        delete.DeleteActionView.__call__(self)  # run the parent class function for this child
 
         # only send the success message on the second request, which does not contain 'render'
         if not self.request.form.get('render') == 'yes':

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -232,6 +232,8 @@ class TrashActionView(delete.DeleteActionView):
         # only send the success message on the second request, which does not contain 'render'
         if not self.request.form.get('render') == 'yes':
             return self.message_async()
+        else:
+            return self.json({})  # this is needed to prevent "Error loading popover from server."
 
 
 @implementer(IStructureAction)

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -213,12 +213,18 @@ class TrashActionView(delete.DeleteActionView):
     def action(self, obj):
         from chameleon import PageTemplate
         trash.object(obj)
-        if not hasattr(self, multiple_items) or self.multiple_items is False:
+        if not hasattr(self, 'multiple_items') or self.multiple_items == False:
             self.multiple_items = True
-            self.success_msg = PageTemplate("Successfully moved <a tal:attributes='href obj.absolute_url()'> tal:attribute='obj.Title()' </a> to recycle bin")
+            self.success_msg = PageTemplate("""<div tal:define="Std modules/Products.PythonScripts/standard;
+                 restructured_text nocall: Std/restructured_text;"
+    tal:content="structure python: restructured_text(context.Description())">
+<p>Successfully moved <a tal:attributes='href obj.absolute_url()' tal:content='obj.Title()' class='link'> </a> to recycle bin</p>
+</div>
+""")
             self.success_msg = PageTemplate.render(self.success_msg, obj=obj)
         else:
             self.success_msg = 'Successfully moved items to recycle bin'
+            self.multiple_items = True
 
 
 @implementer(IStructureAction)

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -213,6 +213,9 @@ class TrashActionView(delete.DeleteActionView):
                 'label': 'Recycled',
                 'type': 'success',
                 'text': '',
+                # the JavaScript that handles the html render is located at:
+                # https://github.com/castlecms/castle.cms/blob/4ec4b7b197be7e808738d33dcf4f25bae6d519b5
+                # /castle/cms/static/scripts/patches.js#L25
                 'html': 'Successfully moved items to <a href="./@@trash">Recycle Bin</a>.',
             }
         })

--- a/castle/cms/browser/trash.py
+++ b/castle/cms/browser/trash.py
@@ -51,8 +51,8 @@ class TrashView(BrowserView):
     def restore(self):
         uid = self.request.get('uid')
         obj = self.get_by_uid(uid)
-        api.portal.show_message(u'Successfully restored "%s" located at: %s' % (
-            unidecode(obj.Title()), self.get_path(obj)), self.request, type='info')
+        api.portal.show_message(u'Successfully restored <a href=%s> "%s" </a>' % (
+            obj.absolute_url(), unidecode(obj.Title())), self.request, type='info')
         trash.restore(obj)
 
     def delete(self):

--- a/castle/cms/browser/trash.py
+++ b/castle/cms/browser/trash.py
@@ -72,7 +72,7 @@ class TrashView(BrowserView):
 
         self.send_IStatusMessage_info_with_location('Successfully restored: ' +
             unidecode(obj.Title()), self.get_path(obj))
-        
+
         trash.restore(obj)
 
     def delete(self):

--- a/castle/cms/browser/trash.py
+++ b/castle/cms/browser/trash.py
@@ -56,6 +56,9 @@ class TrashView(BrowserView):
         return unicode(json.dumps({
             'text': text,
             'location': location,
+            # the JS handles this special case here:
+            # https://github.com/castlecms/castle.cms
+            # /blob/9e6ea3a4a6dcd07b28cc39b2e950b21e6e2d3d81/castle/cms/static/patterns/toolbar.js#L554
             'parseAsJSON': True
         }), 'utf-8')
 

--- a/castle/cms/browser/trash.py
+++ b/castle/cms/browser/trash.py
@@ -10,6 +10,8 @@ from unidecode import unidecode
 from zope.event import notify
 from castle.cms.events import TrashEmptiedEvent
 
+import json
+
 
 class TrashView(BrowserView):
 
@@ -48,11 +50,23 @@ class TrashView(BrowserView):
     def get_by_uid(self, uid):
         return self.catalog(UID=uid, trashed=True)[0].getObject()
 
+    # used for modifying the location in a IStatusMessage
+    # if we need this for something else we can move it to a static function library
+    def _special_IStatusMessage_fmt(self, text, location):
+        return unicode(json.dumps({
+            'text': text,
+            'location': location,
+            'parseAsJSON': True
+        }), 'utf-8')
+
+    # wrapper for _special_IStatusMessage_fmt and api.portal.show_message
+    def send_IStatusMessage_info_with_location(self, text, location):
+        api.portal.show_message(self._special_IStatusMessage_fmt(text, location), self.request, type='info')
+
     def restore(self):
         uid = self.request.get('uid')
         obj = self.get_by_uid(uid)
-        api.portal.show_message(u'Successfully restored <a href=%s> "%s" </a>' % (
-            obj.absolute_url(), unidecode(obj.Title())), self.request, type='info')
+        self.send_IStatusMessage_info_with_location('Successfully restored: ' + unidecode(obj.Title()), self.get_path(obj))
         trash.restore(obj)
 
     def delete(self):

--- a/castle/cms/browser/trash.py
+++ b/castle/cms/browser/trash.py
@@ -70,8 +70,10 @@ class TrashView(BrowserView):
         uid = self.request.get('uid')
         obj = self.get_by_uid(uid)
 
-        self.send_IStatusMessage_info_with_location('Successfully restored: ' +
-            unidecode(obj.Title()), self.get_path(obj))
+        self.send_IStatusMessage_info_with_location(
+            'Successfully restored: ' +
+            unidecode(obj.Title()), self.get_path(obj)
+        )
 
         trash.restore(obj)
 

--- a/castle/cms/browser/trash.py
+++ b/castle/cms/browser/trash.py
@@ -69,7 +69,10 @@ class TrashView(BrowserView):
     def restore(self):
         uid = self.request.get('uid')
         obj = self.get_by_uid(uid)
-        self.send_IStatusMessage_info_with_location('Successfully restored: ' + unidecode(obj.Title()), self.get_path(obj))
+
+        self.send_IStatusMessage_info_with_location('Successfully restored: ' +
+            unidecode(obj.Title()), self.get_path(obj))
+        
         trash.restore(obj)
 
     def delete(self):

--- a/castle/cms/static/patterns/toolbar.js
+++ b/castle/cms/static/patterns/toolbar.js
@@ -551,6 +551,15 @@ define([
 
     renderMenuItem: function(item){
       var loc = '';
+      if(item.text.split('{\"parseAsJSON\": true').length > 1) {
+        try {
+          var _parsed = JSON.parse(item.text);
+          item.text = _parsed.text;
+          item.context = _parsed.location;
+        } catch(JSONParseException) {
+          console.error('toolbar.js: renderMenuItem JSONParseException', JSONParseException);
+        }
+      }
       if(item.context){
         loc = D.div({ className: 'location' }, [
           D.span({}, 'Location: '),

--- a/castle/cms/static/scripts/patches.js
+++ b/castle/cms/static/scripts/patches.js
@@ -22,6 +22,32 @@ require([
   'jquery',
   'mockup-patterns-modal',
 ], function($, Modal) {
+  // global context script which allows html to be rendered in @fc-trash success messages
+  (function($, setTimeout, kvs) {
+      parseResponseHTML = function(restext) {
+          return JSON.parse(restext)['msg']['html'];
+      };
+
+      if(!kvs['trash_html_event_bound']) { // check if we have bound this event already
+          $(document).ajaxSuccess(function(event, xhr, settings) { // bind event to ajaxSuccess
+              if( (settings.url.split('@@fc-trash').length > 1) && (!(settings.data.split('&render=yes').length > 1)) ) { // only run on @@fc-trash AJAX requests where "&render=yes" does not exist in the request data
+                  setTimeout(function() {
+                      $('.alert-success').find('span').html(parseResponseHTML(xhr.responseText)); // inject the HTML
+                  }, 250); //wait a bit because underscore will render first and then this function will overide it
+              }
+          });
+
+          kvs['trash_html_event_bound'] = true; // prevent this event from being bound to the Global Ajax Event Handler multiple times
+      }
+  })($, window.setTimeout, (function() {
+      // basic object based key value storage -- accessed as "kvs" in the main function above
+      if(typeof window.__ === 'undefined') {
+          window.__ = {};
+      }
+
+      return window.__;
+  })());
+
   if(Modal.prototype._init === undefined){
     Modal.prototype._init = Modal.prototype.init;
     Modal.prototype.init = function(){


### PR DESCRIPTION
These changes add two features:
1) A link to go to the Recycle Bin when recycling an item
2) A link to go to the item from the notification when restoring it from the Recycle Bin

In order to implement this I had to make some changes to the JavaScript, so a rebuild of the minified sources may be necessary.


The fix in [static/scripts/patches.js](https://github.com/castlecms/castle.cms/blob/a7e2707b4300612581fca399648b046266384ae5/castle/cms/static/scripts/patches.js) uses [jQuery Global Ajax Event Handlers](https://api.jquery.com/category/ajax/global-ajax-event-handlers/) to add the Recycle Bin link 250ms after the underlying AJAX request, which is making an assumption that the underscore template can render it in less time than that. Even if this code fails (because of lag?), the notification will still say "Recycled", it just won't have the nice link to the Recycle Bin. In my tests on my local machine which is a pretty slow MacBook Air, 250ms is more than enough time for underscore to render the template.