### PR TITLE
626 -> javascript_head_slot replaced with add_resource_on_request

### DIFF
--- a/castle/cms/browser/audit.py
+++ b/castle/cms/browser/audit.py
@@ -4,6 +4,7 @@ from cStringIO import StringIO
 from plone import api
 from plone.app.uuid.utils import uuidToObject
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.resources import add_resource_on_request
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getUtility
@@ -20,6 +21,9 @@ class AuditView(BrowserView):
     error_template = ViewPageTemplateFile('templates/audit-error.pt')
 
     def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-audit')
+
         self._user_cache = {}
         self.site_path = '/'.join(self.context.getPhysicalPath())
         try:

--- a/castle/cms/browser/controlpanel/archival.py
+++ b/castle/cms/browser/controlpanel/archival.py
@@ -5,6 +5,7 @@ from castle.cms.files import aws
 from DateTime import DateTime
 from plone import api
 from plone.app.uuid.utils import uuidToObject
+from Products.CMFPlone.resources import add_resource_on_request
 from Products.Five import BrowserView
 from zope.component import getMultiAdapter
 
@@ -188,6 +189,10 @@ class AWSApi(object):
 class Manage(BaseView):
 
     def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-manage-archives')
+        return super(Manage, self).__call__()
+
         if self.request.form.get('api'):
             self.request.response.setHeader('Content-type', 'application/json')
             return json.dumps(AWSApi(self.context, self.request)())

--- a/castle/cms/browser/controlpanel/audit.py
+++ b/castle/cms/browser/controlpanel/audit.py
@@ -1,6 +1,12 @@
+from Products.CMFPlone.resources import add_resource_on_request
 from castle.cms.browser.audit import AuditView as BaseAuditView
 
 
 class AuditView(BaseAuditView):
+    def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-audit')
+        return super(AuditView, self).__call__()
+
     label = 'Audit Log'
     user = False

--- a/castle/cms/browser/controlpanel/tags.py
+++ b/castle/cms/browser/controlpanel/tags.py
@@ -1,5 +1,6 @@
 from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone import api
+from Products.CMFPlone.resources import add_resource_on_request
 from Products.Five import BrowserView
 import json
 
@@ -11,6 +12,9 @@ class TagsView(BrowserView):
     remove_size = 25
 
     def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-tag-manager')
+
         action = self.request.form.get('action')
         if action:
             self.request.response.setHeader('Content-type', 'application/json')

--- a/castle/cms/browser/controlpanel/templates/archives-manage.pt
+++ b/castle/cms/browser/controlpanel/templates/archives-manage.pt
@@ -9,11 +9,6 @@
 <body>
 
 
-  <metal:javascript fill-slot="javascript_head_slot">
-    <script src="${portal_url}/++plone++castle/components/manage-archives.js?v=3"></script>
-  </metal:javascript>
-
-
 <metal:main metal:fill-slot="prefs_configlet_main" i18n:domain="plone">
 
     <a href=""

--- a/castle/cms/browser/controlpanel/templates/audit.pt
+++ b/castle/cms/browser/controlpanel/templates/audit.pt
@@ -6,10 +6,6 @@
       metal:use-macro="context/prefs_main_template/macros/master"
       i18n:domain="plone">
 
-  <metal:javascript fill-slot="javascript_head_slot">
-    <script src="${portal_url}/++plone++castle/components/audit.js"></script>
-  </metal:javascript>
-
 <body>
 
 <metal:main metal:fill-slot="prefs_configlet_main"

--- a/castle/cms/browser/controlpanel/templates/tags.pt
+++ b/castle/cms/browser/controlpanel/templates/tags.pt
@@ -7,11 +7,6 @@
       i18n:domain="plone">
 
 <body>
-
-  <metal:javascript fill-slot="javascript_head_slot">
-    <script src="${portal_url}/++plone++castle/components/tag-manager.js"></script>
-  </metal:javascript>
-
 <metal:main metal:fill-slot="prefs_configlet_main">
 
     <a href=""

--- a/castle/cms/browser/controlpanel/templates/usergroups_usersoverview.pt
+++ b/castle/cms/browser/controlpanel/templates/usergroups_usersoverview.pt
@@ -6,9 +6,6 @@
     metal:use-macro="context/prefs_main_template/macros/master"
     i18n:domain="plone">
 
-<metal:javascript fill-slot="javascript_head_slot">
-<script src="${portal_url}/++plone++castle/components/usersgroups.js"></script>
-</metal:javascript>
 
 <body>
 

--- a/castle/cms/browser/controlpanel/usergroups.py
+++ b/castle/cms/browser/controlpanel/usergroups.py
@@ -12,7 +12,7 @@ class UsersOverviewControlPanel(usergroups_usersoverview.UsersOverviewControlPan
     def __call__(self):
         # utility function to add resource to rendered page
         add_resource_on_request(self.request, 'castle-components-usersgroups')
-        return super(Search, self).__call__()
+        return super(UsersOverviewControlPanel, self).__call__()
 
     def manageUser(self, users=[], resetpassword=[], delete=[]):
         super(UsersOverviewControlPanel, self).manageUser(

--- a/castle/cms/browser/controlpanel/usergroups.py
+++ b/castle/cms/browser/controlpanel/usergroups.py
@@ -2,12 +2,18 @@ from Acquisition import aq_inner
 from castle.cms.lockout import LockoutManager
 from plone import api
 from Products.CMFPlone.controlpanel.browser import usergroups_usersoverview
+from Products.CMFPlone.resources import add_resource_on_request
 from zExceptions import Forbidden
 
 import time
 
 
 class UsersOverviewControlPanel(usergroups_usersoverview.UsersOverviewControlPanel):
+    def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-usersgroups')
+        return super(Search, self).__call__()
+
     def manageUser(self, users=[], resetpassword=[], delete=[]):
         super(UsersOverviewControlPanel, self).manageUser(
             users=users, resetpassword=resetpassword, delete=delete)

--- a/castle/cms/browser/history.py
+++ b/castle/cms/browser/history.py
@@ -23,10 +23,9 @@ import json
 
 class HistoryView(HistoryByLineView):
     def __call__(self):
-         # utility function to add resource to rendered page
-         add_resource_on_request(self.request, 'castle-components-history')
-         return super(HistoryView, self).__call__()
-
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-history')
+        return super(HistoryView, self).__call__()
 
     index = ViewPageTemplateFile('templates/history_view.pt')
 

--- a/castle/cms/browser/history.py
+++ b/castle/cms/browser/history.py
@@ -11,6 +11,7 @@ from plone.protect.interfaces import IDisableCSRFProtection
 from Products.CMFEditions.browser.diff import DiffView
 from Products.CMFPlone.browser.syndication.adapters import SearchFeed
 from Products.CMFPlone.interfaces.syndication import IFeedItem
+from Products.CMFPlone.resources import add_resource_on_request
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryMultiAdapter

--- a/castle/cms/browser/history.py
+++ b/castle/cms/browser/history.py
@@ -21,6 +21,12 @@ import json
 
 
 class HistoryView(HistoryByLineView):
+    def __call__(self):
+         # utility function to add resource to rendered page
+         add_resource_on_request(self.request, 'castle-components-history')
+         return super(HistoryView, self).__call__()
+
+
     index = ViewPageTemplateFile('templates/history_view.pt')
 
     def show(self):

--- a/castle/cms/browser/history.py
+++ b/castle/cms/browser/history.py
@@ -48,12 +48,6 @@ class ContentHistoryView(BaseContentHistoryView):
 
 
 class HistoryVersionView(DiffView):
-    def __call__(self):
-         # utility function to add resource to rendered page
-         add_resource_on_request(self.request, 'castle-components-history')
-         return super(HistoryVersionView, self).__call__()
-
-
     template = ViewPageTemplateFile("templates/history_version.pt")
 
     def getContent(self, version):
@@ -95,6 +89,9 @@ class HistoryVersionView(DiffView):
         return version_history
 
     def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-history')
+
         alsoProvides(self.request, IDisableCSRFProtection)
         self.version_info = None
         for version in self.versions:

--- a/castle/cms/browser/history.py
+++ b/castle/cms/browser/history.py
@@ -48,6 +48,12 @@ class ContentHistoryView(BaseContentHistoryView):
 
 
 class HistoryVersionView(DiffView):
+    def __call__(self):
+         # utility function to add resource to rendered page
+         add_resource_on_request(self.request, 'castle-components-history')
+         return super(HistoryVersionView, self).__call__()
+
+
     template = ViewPageTemplateFile("templates/history_version.pt")
 
     def getContent(self, version):

--- a/castle/cms/browser/search.py
+++ b/castle/cms/browser/search.py
@@ -6,6 +6,7 @@ from DateTime import DateTime
 from elasticsearch import TransportError
 from plone import api
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.resources import add_resource_on_request
 from Products.CMFCore.utils import _getAuthenticatedUser
 from Products.Five import BrowserView
 from urlparse import urljoin
@@ -36,6 +37,10 @@ def _one(val):
 
 
 class Search(BrowserView):
+    def __call__(self):
+        # utility function to add resource to rendered page
+        add_resource_on_request(self.request, 'castle-components-search')
+        return super(Search, self).__call__()
 
     @property
     def options(self):

--- a/castle/cms/browser/templates/audit-log.pt
+++ b/castle/cms/browser/templates/audit-log.pt
@@ -6,10 +6,6 @@
     metal:use-macro="context/main_template/macros/master"
     i18n:domain="plone">
 
-<metal:javascript fill-slot="javascript_head_slot">
-  <script src="${portal_url}/++plone++castle/components/audit.js"></script>
-</metal:javascript>
-
 <body tal:define="connected view/el_connected;
                   site_path python: '/'.join(context.getPhysicalPath())">
 

--- a/castle/cms/browser/templates/history_version.pt
+++ b/castle/cms/browser/templates/history_version.pt
@@ -7,13 +7,6 @@
       i18n:domain="plone">
 
 <head>
-  <metal:javascript fill-slot="javascript_head_slot">
-    <script src="${portal_url}/++plone++castle/components/history.js"></script>
-  </metal:javascript>
-  <metal:block fill-slot="style_slot">
-    <link rel="stylesheet" type="text/css"
-          href="${portal_url}/++plone++castle/less/misc/history.css">
-  </metal:block>
 </head>
 
 <body>

--- a/castle/cms/browser/templates/history_view.pt
+++ b/castle/cms/browser/templates/history_view.pt
@@ -7,13 +7,6 @@
       i18n:domain="plone">
 
 <head>
-  <metal:javascript fill-slot="javascript_head_slot">
-    <script src="${portal_url}/++plone++castle/components/history.js"></script>
-  </metal:javascript>
-  <metal:block fill-slot="style_slot">
-    <link rel="stylesheet" type="text/css"
-          href="${portal_url}/++plone++castle/less/misc/history.css">
-  </metal:block>
 </head>
 
 <body>

--- a/castle/cms/browser/templates/search.pt
+++ b/castle/cms/browser/templates/search.pt
@@ -14,10 +14,6 @@
     <link rel="stylesheet" type="text/css"
           href="${portal_url}/++plone++castle/less/misc/search.css?v=5">
   </metal:block>
-  <metal:javascript fill-slot="javascript_head_slot">
-    <script type="text/javascript" src="${context/portal_url}/++plone++castle/components/search.js?v=6">
-    </script>
-  </metal:javascript>
 </head>
 
 <body>

--- a/castle/cms/browser/templates/search.pt
+++ b/castle/cms/browser/templates/search.pt
@@ -10,10 +10,6 @@
   <metal:block fill-slot="top_slot"
                tal:define="disable_column_one python:request.set('disable_plone.leftcolumn',1);
                            disable_column_two python:request.set('disable_plone.rightcolumn',1);" />
-  <metal:block fill-slot="style_slot">
-    <link rel="stylesheet" type="text/css"
-          href="${portal_url}/++plone++castle/less/misc/search.css?v=5">
-  </metal:block>
 </head>
 
 <body>

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -131,6 +131,13 @@
       <value key="deps">plone-logged-in</value>
   </records>
 
+  <!-- castle-components-tag-manager -->
+  <records prefix="plone.resources/castle-components-tag-manager"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++castle/components/tag-manager.js</value>
+      <value key="deps">plone-logged-in</value>
+  </records>
+
 
   <!-- need to override tinymce pattern... -->
   <records prefix="plone.resources/mockup-patterns-tinymce"

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -162,6 +162,16 @@
       <value key="deps">plone-logged-in</value>
   </records>
 
+  <!-- castle-components-history -->
+  <records prefix="plone.resources/castle-components-history"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++castle/components/history.js</value>
+      <value key="css">
+        <element>++plone++castle/less/misc/history.css</element>
+      </value>
+      <value key="deps">plone-logged-in</value>
+  </records>
+
 
   <!-- need to override tinymce pattern... -->
   <records prefix="plone.resources/mockup-patterns-tinymce"

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -148,6 +148,13 @@
       <value key="deps">plone-logged-in</value>
   </records>
 
+  <!-- castle-components-audit -->
+  <records prefix="plone.resources/castle-components-audit"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++castle/components/audit.js</value>
+      <value key="deps">plone-logged-in</value>
+  </records>
+
 
   <!-- need to override tinymce pattern... -->
   <records prefix="plone.resources/mockup-patterns-tinymce"

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -121,6 +121,17 @@
       </value>
   </records>
 
+
+  <!-- depends on plone-logged-in -->
+
+   <!-- castle-components-search -->
+  <records prefix="plone.resources/castle-components-search"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++castle/components/search.js</value>
+      <value key="deps">plone-logged-in</value>
+  </records>
+
+
   <!-- need to override tinymce pattern... -->
   <records prefix="plone.resources/mockup-patterns-tinymce"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -156,9 +156,9 @@
   </records>
 
   <!-- castle-components-archives-manage -->
-  <records prefix="plone.resources/castle-components-archives-manage"
+  <records prefix="plone.resources/castle-components-manage-archives"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
-      <value key="js">++plone++castle/components/archives-manage.js</value>
+      <value key="js">++plone++castle/components/manage-archives.js</value>
       <value key="deps">plone-logged-in</value>
   </records>
 

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -124,7 +124,7 @@
 
   <!-- depends on plone-logged-in -->
 
-   <!-- castle-components-search -->
+  <!-- castle-components-search -->
   <records prefix="plone.resources/castle-components-search"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
       <value key="js">++plone++castle/components/search.js</value>

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -122,7 +122,7 @@
   </records>
 
 
-  <!-- depends on plone-logged-in -->
+  <!-- depends on plone -->
 
   <!-- castle-components-search -->
   <records prefix="plone.resources/castle-components-search"
@@ -130,6 +130,9 @@
       <value key="js">++plone++castle/components/search.js</value>
       <value key="deps">plone</value>
   </records>
+
+
+  <!-- depends on plone-logged-in -->
 
   <!-- castle-components-tag-manager -->
   <records prefix="plone.resources/castle-components-tag-manager"

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -128,6 +128,9 @@
   <records prefix="plone.resources/castle-components-search"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
       <value key="js">++plone++castle/components/search.js</value>
+      <value key="css">
+        <element>++plone++castle/less/misc/search.css</element>
+      </value>
       <value key="deps">plone</value>
   </records>
 

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -155,6 +155,13 @@
       <value key="deps">plone-logged-in</value>
   </records>
 
+  <!-- castle-components-archives-manage -->
+  <records prefix="plone.resources/castle-components-archives-manage"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++castle/components/archives-manage.js</value>
+      <value key="deps">plone-logged-in</value>
+  </records>
+
 
   <!-- need to override tinymce pattern... -->
   <records prefix="plone.resources/mockup-patterns-tinymce"

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -141,6 +141,13 @@
       <value key="deps">plone-logged-in</value>
   </records>
 
+  <!-- castle-components-usersgroups -->
+  <records prefix="plone.resources/castle-components-usersgroups"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++castle/components/usersgroups.js</value>
+      <value key="deps">plone-logged-in</value>
+  </records>
+
 
   <!-- need to override tinymce pattern... -->
   <records prefix="plone.resources/mockup-patterns-tinymce"

--- a/castle/cms/profiles/default/registry/resources.xml
+++ b/castle/cms/profiles/default/registry/resources.xml
@@ -128,7 +128,7 @@
   <records prefix="plone.resources/castle-components-search"
             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
       <value key="js">++plone++castle/components/search.js</value>
-      <value key="deps">plone-logged-in</value>
+      <value key="deps">plone</value>
   </records>
 
   <!-- castle-components-tag-manager -->

--- a/castle/cms/static/components/search.js
+++ b/castle/cms/static/components/search.js
@@ -1,6 +1,5 @@
 /*global history */
 
-window.addEventListener('load', function(){
 
 require([
   'jquery',
@@ -603,7 +602,5 @@ require([
       show: null
     });
   });
-
-});
 
 });

--- a/castle/cms/static/components/tag-manager.js
+++ b/castle/cms/static/components/tag-manager.js
@@ -1,5 +1,3 @@
-window.addEventListener('load', function(){
-
 require([
   'jquery',
   'castle-url/libs/react/react.min',
@@ -295,6 +293,4 @@ require([
   var el = document.getElementById('tag-manager');
 
   var component = R.render(R.createElement(TagManagerComponent, {}), el);
-});
-
 });


### PR DESCRIPTION
This should cover all relevant instances of `javascript_head_slot` in the codebase.
```
√ castle.cms % search javascript_head_slot
grep -r "javascript_head_slot" * --exclude "*.pyc" --exclude "env*" --exclude "*.min.js" --exclude "highlight.js" --exclude "castle.cms.egg-info/*" --exclude "*.min.css" --exclude "*.css.map"
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
castle/cms/theming.py:jsslot_xpath = etree.XPath('//*[@id="javascript_head_slot"]')
castle/cms/theming.py:        1) implement javascript_head_slot
castle/cms/theming.py:        # add children of javascript_head_slot after all other
castle/cms/skins/castle/login_form.cpt: <metal:javascript fill-slot="javascript_head_slot">
castle/cms/skins/castle/logged_out.cpt:   <metal:javascript fill-slot="javascript_head_slot">
castle/cms/browser/controlpanel/templates/archives-review.pt:  <metal:javascript fill-slot="javascript_head_slot">
castle/cms/browser/controlpanel/templates/links.pt:  <metal:javascript fill-slot="javascript_head_slot">
castle/cms/browser/layout/templates/main_template.pt:    <div id="javascript_head_slot" style="display:none">
castle/cms/browser/layout/templates/main_template.pt:      <metal:javascriptslot define-slot="javascript_head_slot" />
castle/cms/browser/templates/trash.pt:  <metal:javascript fill-slot="javascript_head_slot">
castle/cms/browser/templates/add-content-type.pt:    <div id="javascript_head_slot" style="display:none">
castle/cms/browser/templates/add-content-type.pt:      <metal:javascriptslot define-slot="javascript_head_slot" />
```

And here is a list of those search results with links to the code:
[castle/cms/skins/castle/login_form.cpt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/skins/castle/login_form.cpt#L13)
[castle/cms/skins/castle/logged_out.cpt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/skins/castle/logged_out.cpt#L13)
[castle/cms/browser/controlpanel/templates/archives-review.pt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/browser/controlpanel/templates/archives-review.pt#L11)
[castle/cms/browser/controlpanel/templates/links.pt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/browser/controlpanel/templates/links.pt#L9)
[castle/cms/browser/layout/templates/main_template.pt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/browser/layout/templates/main_template.pt#L47)
[castle/cms/browser/templates/trash.pt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/browser/templates/trash.pt#L10)
[castle/cms/browser/templates/add-content-type.pt](https://github.com/castlecms/castle.cms/blob/master/castle/cms/browser/templates/add-content-type.pt#L52)

This PR also adds the following to the [resource registry](https://github.com/castlecms/castle.cms/blob/374918d29a7f54b8d6cdb3af94349ec37ad8cfc6/castle/cms/profiles/default/registry/resources.xml#L124):
![Screen Shot 2020-05-22 at 11 54 32 AM](https://user-images.githubusercontent.com/2145492/82691434-822d0b80-9c23-11ea-8ae1-3034cbd99b32.png)
