### PR TITLE
ignore export directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ temp_resources/
 env
 env2
 dump.rdb
+export/
 /Makefile
 /package.json
 /watch-run.py


### PR DESCRIPTION
Ignore the default export directory to help prevent accidental commits of content.
