### PR TITLE
Bd/search tweak

### DIFF
--- a/castle/cms/browser/controlpanel/settings.py
+++ b/castle/cms/browser/controlpanel/settings.py
@@ -1,6 +1,6 @@
 from castle.cms.interfaces import (IAPISettings, IArchivalSettings,
                                    ICastleSettings, IContentSettings,
-                                   ISiteConfiguration)
+                                   ISiteConfiguration, IConfigurableTextSettings)
 from castle.cms.widgets import FileUploadFieldsFieldWidget, SelectFieldWidget
 from plone.app.registry.browser import controlpanel
 from plone.formwidget.namedfile.widget import NamedFileFieldWidget
@@ -24,6 +24,11 @@ class ContentForm(group.GroupForm):
     fields = field.Fields(IContentSettings)
 
 
+class ConfigurableTextForm(group.GroupForm):
+    label = u"Configurable Text"
+    fields = field.Fields(IConfigurableTextSettings)
+
+
 class CastleSettingsControlPanelForm(controlpanel.RegistryEditForm):
 
     id = "CastleSettingsControlPanel"
@@ -32,7 +37,7 @@ class CastleSettingsControlPanelForm(controlpanel.RegistryEditForm):
     schema = ICastleSettings
     schema_prefix = "castle"
     fields = field.Fields(ISiteConfiguration)
-    groups = (APIForm, ArchivalForm, ContentForm)
+    groups = (APIForm, ArchivalForm, ContentForm, ConfigurableTextForm)
 
     def updateFields(self):
         super(CastleSettingsControlPanelForm, self).updateFields()

--- a/castle/cms/browser/controlpanel/settings.py
+++ b/castle/cms/browser/controlpanel/settings.py
@@ -1,6 +1,7 @@
 from castle.cms.interfaces import (IAPISettings, IArchivalSettings,
                                    ICastleSettings, IContentSettings,
-                                   ISiteConfiguration, IConfigurableTextSettings)
+                                   ISiteConfiguration, ISearchSettings,
+                                   ISlideshowSettings)
 from castle.cms.widgets import FileUploadFieldsFieldWidget, SelectFieldWidget
 from plone.app.registry.browser import controlpanel
 from plone.formwidget.namedfile.widget import NamedFileFieldWidget
@@ -26,7 +27,7 @@ class ContentForm(group.GroupForm):
 
 class ConfigurableTextForm(group.GroupForm):
     label = u"Configurable Text"
-    fields = field.Fields(IConfigurableTextSettings)
+    fields = field.Fields(ISearchSettings, ISlideshowSettings)
 
 
 class CastleSettingsControlPanelForm(controlpanel.RegistryEditForm):

--- a/castle/cms/browser/search.py
+++ b/castle/cms/browser/search.py
@@ -111,9 +111,10 @@ class Search(BrowserView):
         parsed = urlparse(get_public_url())
 
         return json.dumps({
-            'searchTypes': search_types,
+            'searchTypes': [s for s in sorted(search_types, key=lambda st: st['label'])],
             'additionalSites': [s for s in sorted(additional_sites)],
-            'currentSiteLabel': parsed.netloc
+            'currentSiteLabel': parsed.netloc,
+            'searchHelpText': 'Hey there'
         })
 
     @property

--- a/castle/cms/browser/search.py
+++ b/castle/cms/browser/search.py
@@ -46,7 +46,7 @@ class Search(BrowserView):
     def options(self):
         search_types = [{
             'id': 'images',
-            'label': 'Images',
+            'label': 'Image',
             'query': {
                 'portal_type': 'Image'
             }
@@ -59,11 +59,12 @@ class Search(BrowserView):
         }]
 
         ptypes = api.portal.get_tool('portal_types')
+        allow_anyway = ['Audio']
         for type_id in ptypes.objectIds():
             if type_id in ('Link', 'Document', 'Folder'):
                 continue
             _type = ptypes[type_id]
-            if not _type.global_allow:
+            if not _type.global_allow and type_id not in allow_anyway:
                 continue
             search_types.append({
                 'id': type_id.lower(),
@@ -72,19 +73,14 @@ class Search(BrowserView):
                     'portal_type': type_id
                 }
             })
-        search_types.extend([{
-            'id': 'video',
-            'label': 'Video',
-            'query': {
-                'portal_type': 'Video'
-            }
-        }, {
-            'id': 'audio',
-            'label': 'Audio',
-            'query': {
-                'portal_type': 'Audio'
-            }
-        }])
+        # search_types.append({
+        #     'id': 'audio',
+        #     'label': 'Audio',
+        #     'query': {
+        #         'portal_type': 'Audio'
+        #     }
+        # })
+        # search_types.sort(key=lambda type: type['label'])
 
         additional_sites = []
         es = ElasticSearchCatalog(api.portal.get_tool('portal_catalog'))

--- a/castle/cms/browser/search.py
+++ b/castle/cms/browser/search.py
@@ -109,12 +109,11 @@ class Search(BrowserView):
                 pass
 
         parsed = urlparse(get_public_url())
-
         return json.dumps({
             'searchTypes': [s for s in sorted(search_types, key=lambda st: st['label'])],
             'additionalSites': [s for s in sorted(additional_sites)],
             'currentSiteLabel': parsed.netloc,
-            'searchHelpText': 'Hey there'
+            'searchHelpText': api.portal.get_registry_record('castle.search_page_help_text', None),
         })
 
     @property

--- a/castle/cms/browser/search.py
+++ b/castle/cms/browser/search.py
@@ -110,8 +110,8 @@ class Search(BrowserView):
 
         parsed = urlparse(get_public_url())
         return json.dumps({
-            'searchTypes': [s for s in sorted(search_types, key=lambda st: st['label'])],
-            'additionalSites': [s for s in sorted(additional_sites)],
+            'searchTypes': sorted(search_types, key=lambda st: st['label']),
+            'additionalSites': sorted(additional_sites),
             'currentSiteLabel': parsed.netloc,
             'searchHelpText': api.portal.get_registry_record('castle.search_page_help_text', None),
         })

--- a/castle/cms/interfaces/__init__.py
+++ b/castle/cms/interfaces/__init__.py
@@ -23,7 +23,8 @@ from .controlpanel import ICrawlerConfiguration
 from .controlpanel import ISecuritySchema
 from .controlpanel import ISiteConfiguration
 from .controlpanel import ISiteSchema
-from .controlpanel import IConfigurableTextSettings
+from .controlpanel import ISearchSettings
+from .controlpanel import ISlideshowSettings
 from .controlpanel import ISocialMediaSchema
 from .layers import ICastleLayer
 from .layers import IVersionViewLayer

--- a/castle/cms/interfaces/__init__.py
+++ b/castle/cms/interfaces/__init__.py
@@ -23,7 +23,7 @@ from .controlpanel import ICrawlerConfiguration
 from .controlpanel import ISecuritySchema
 from .controlpanel import ISiteConfiguration
 from .controlpanel import ISiteSchema
-from .controlpanel import ISlideshowSettings
+from .controlpanel import IConfigurableTextSettings
 from .controlpanel import ISocialMediaSchema
 from .layers import ICastleLayer
 from .layers import IVersionViewLayer

--- a/castle/cms/interfaces/controlpanel.py
+++ b/castle/cms/interfaces/controlpanel.py
@@ -497,7 +497,16 @@ class IContentSettings(Interface):
     # but will require a custom widget
 
 
-class ISlideshowSettings(Interface):
+class IConfigurableTextSettings(Interface):
+    search_page_help_text = schema.TextLine(
+        title=u'Search Page Help Text',
+        description=u'The help text a user sees between the search bar and search results at /@@search. '
+                    u'This text element will be omitted if blank',
+        required=False,
+        default=u'To narrow your search, select a content type option shown in the toolbar below or listed under "More Filters". ' # noqa
+                u'To broaden your search to other crawled sites, select a subdomain listed under "Source."' # noqa
+    )
+
     resource_slide_view_more_link_text = schema.TextLine(
         title=u"View More link text",
         description=u'The text a user sees for the optional link at the bottom of the slideshow resource slide. ' # noqa
@@ -513,7 +522,7 @@ class ISlideshowSettings(Interface):
 
 class ICastleSettings(ISiteConfiguration, IAPISettings,
                       IArchivalSettings, IContentSettings,
-                      ISlideshowSettings):
+                      IConfigurableTextSettings):
     pass
 
 

--- a/castle/cms/interfaces/controlpanel.py
+++ b/castle/cms/interfaces/controlpanel.py
@@ -497,7 +497,7 @@ class IContentSettings(Interface):
     # but will require a custom widget
 
 
-class IConfigurableTextSettings(Interface):
+class ISearchSettings(Interface):
     search_page_help_text = schema.TextLine(
         title=u'Search Page Help Text',
         description=u'The help text a user sees between the search bar and search results at /@@search. '
@@ -507,6 +507,8 @@ class IConfigurableTextSettings(Interface):
                 u'To broaden your search to other crawled sites, select a subdomain listed under "Source."' # noqa
     )
 
+
+class ISlideshowSettings(Interface):
     resource_slide_view_more_link_text = schema.TextLine(
         title=u"View More link text",
         description=u'The text a user sees for the optional link at the bottom of the slideshow resource slide. ' # noqa
@@ -522,7 +524,7 @@ class IConfigurableTextSettings(Interface):
 
 class ICastleSettings(ISiteConfiguration, IAPISettings,
                       IArchivalSettings, IContentSettings,
-                      IConfigurableTextSettings):
+                      ISearchSettings, ISlideshowSettings):
     pass
 
 

--- a/castle/cms/profiles/2_6_12/metadata.xml
+++ b/castle/cms/profiles/2_6_12/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>2612</version>
+</metadata>

--- a/castle/cms/profiles/2_6_12/registry/controlpanel.xml
+++ b/castle/cms/profiles/2_6_12/registry/controlpanel.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
           i18n:domain="plone">
- <records interface="castle.cms.interfaces.ISlideshowSettings"
-          remove="true" />
- <records interface="castle.cms.interfaces.IConfigurableTextSettings"
+ <records interface="castle.cms.interfaces.ISearchSettings"
           prefix="castle" />
 </registry>

--- a/castle/cms/profiles/2_6_12/registry/controlpanel.xml
+++ b/castle/cms/profiles/2_6_12/registry/controlpanel.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+ <records interface="castle.cms.interfaces.ISlideshowSettings"
+          remove="true" />
+ <records interface="castle.cms.interfaces.IConfigurableTextSettings"
+          prefix="castle" />
+</registry>

--- a/castle/cms/profiles/default/registry/controlpanel.xml
+++ b/castle/cms/profiles/default/registry/controlpanel.xml
@@ -17,7 +17,7 @@
   <records interface="castle.cms.interfaces.ICrawlerConfiguration"
            prefix="castle" />
   <records interface="castle.cms.interfaces.ISlideshowSettings" 
-           remove="true" />
+           prefix="castle" />
   <records interface="castle.cms.interfaces.ISearchSettings"
            prefix="castle" />
 

--- a/castle/cms/profiles/default/registry/controlpanel.xml
+++ b/castle/cms/profiles/default/registry/controlpanel.xml
@@ -16,7 +16,9 @@
            prefix="castle" />
   <records interface="castle.cms.interfaces.ICrawlerConfiguration"
            prefix="castle" />
-  <records interface="castle.cms.interfaces.IConfigurableTextSettings"
+  <records interface="castle.cms.interfaces.ISlideshowSettings" 
+           remove="true" />
+  <records interface="castle.cms.interfaces.ISearchSettings"
            prefix="castle" />
 
   <records interface="castle.cms.browser.survey.ICastleSurvey" />

--- a/castle/cms/profiles/default/registry/controlpanel.xml
+++ b/castle/cms/profiles/default/registry/controlpanel.xml
@@ -16,7 +16,7 @@
            prefix="castle" />
   <records interface="castle.cms.interfaces.ICrawlerConfiguration"
            prefix="castle" />
-  <records interface="castle.cms.interfaces.ISlideshowSettings"
+  <records interface="castle.cms.interfaces.IConfigurableTextSettings"
            prefix="castle" />
 
   <records interface="castle.cms.browser.survey.ICastleSurvey" />

--- a/castle/cms/static/components/search.js
+++ b/castle/cms/static/components/search.js
@@ -370,18 +370,22 @@ require([
         item.searchSite = that.state.searchSite;
         results.push(R.createElement(SearchResult, item));
       });
-      return D.div({ id: 'search-results-wrapper' }, [
-        D.div({ id: 'search-results-bar' }, [
-          D.span({ id: 'results-count' }, [
+      return D.div({ id: "search-results-wrapper" }, [
+        D.div({ id: "search-results-bar" }, [
+          D.span({ id: "results-count" }, [
             'Page ',
             that.state.page,
+            ' (Results ',
+            (that.state.page - 1) * that.state.pageSize + 1,
+            ' to ',
+            Math.min(that.state.page * that.state.pageSize, that.state.count),
             ' of ',
             that.state.count,
-            ' results'
+            ')'
           ])
         ]),
-        D.div({ id: 'search-results' }, [
-          D.ul({ className: 'searchResults' }, results),
+        D.div({ id: "search-results" }, [
+          D.ul({ className: "searchResults" }, results),
           this.renderPaging()
         ])
       ]);
@@ -541,7 +545,6 @@ require([
           }
         }));
       }
-
       return D.div(
         { className: 'search-options' },
         [

--- a/castle/cms/static/components/search.js
+++ b/castle/cms/static/components/search.js
@@ -173,7 +173,8 @@ require([
         show: null,
         searchSite: this.props.searchSite || false,
         loading: false,
-        sort_on: ''
+        sort_on: '',
+        searchHelpText: this.props.searchHelpText || '',
       };
     },
 
@@ -185,7 +186,8 @@ require([
         searchUrl: $('body').attr('data-portal-url') + '/@@searchajax',
         searchTypes: [],
         additionalSites: [],
-        searchSite: false
+        searchSite: false,
+        searchHelpText: '',
       };
     },
 
@@ -210,11 +212,12 @@ require([
       utils.loading.show();
       var state = {
         SearchableText: that.state.SearchableText,
+        searchHelpText: that.state.searchHelpText,
         pageSize: that.state.pageSize,
         page: that.state.page,
         sort_on: that.state.sort_on,
         sort_order: 'descending',
-        after: that.state.date || ''
+        after: that.state.date || '',
       };
       if(that.state.searchType !== 'all'){
         var type = that.getSearchType(that.state.searchType);
@@ -223,6 +226,9 @@ require([
       }
       if(that.state.searchSite){
         state.searchSite = that.state.searchSite;
+      }
+      if (that.state.searchHelpText) {
+        state.searchHelpText = that.state.searchHelpText;
       }
       if(that.props.Subject){
         state.Subject = that.props.Subject;
@@ -236,21 +242,28 @@ require([
       $.ajax({
         url: this.props.searchUrl,
         data: state
-      }).done(function(data){
+      }).done(function (data) {
+        console.log(data);
         that.props.Subject = undefined;
         that.props['Subject:list'] = undefined;
-        that.setState({
-          results: data.results,
-          count: data.count,
-          page: data.page,
-          error: false,
-          suggestions: data.suggestions || [],
-          loading: false
-        }, function(){
-          $('html, body').animate({
-            scrollTop: 0
-          }, 100);
-        });
+        that.setState(
+          {
+            results: data.results,
+            count: data.count,
+            page: data.page,
+            error: false,
+            suggestions: data.suggestions || [],
+            loading: false,
+          },
+          function () {
+            $('html, body').animate(
+              {
+                scrollTop: 0,
+              },
+              100
+            );
+          }
+        );
 
         if(HasHistory){
           history.pushState(state, "", window.location.origin + window.location.pathname + '?' + $.param(state));
@@ -450,58 +463,13 @@ require([
               that.setState({
                 show: that.state.show === 'more' ? null : 'more'
               });
-            }}, 'More'),
+            }}, 'More Filters'),
             more
           ]));
         }
       }
 
-      if(that.props.additionalSites.length > 0){
-        var current = this.props.currentSiteLabel || 'current site'
-        var items = [['', current]].concat(that.props.additionalSites.map(function(v){
-          return [v, v];
-        }));
-        options.push(R.createElement(SearchOption, {
-          show: that.state.show,
-          type: 'additionalSites',
-          options: items,
-          parent: that,
-          labelPrefix: 'Search: ',
-          value: that.state.searchSite,
-          onClick: function(val) {
-            var searchType = that.state.searchType;
-            var searchSite = false;
-            if (val === current) {
-              searchType = 'all';
-            } else {
-              searchSite = val
-            }
-            that.setState({
-              searchSite: searchSite,
-              page: 1,
-              searchType: searchType
-            }, function(){
-              that.load();
-            });
-          }
-        }));
-      }
-      options.push(R.createElement(SearchOption, {
-        show: that.state.show,
-        type: 'publication',
-        parent: that,
-        options: SortOptions,
-        labelPrefix: 'Sort: ',
-        value: that.state.sort_on,
-        onClick: function(val) {
-          that.setState({
-            sort_on: val
-          }, function(){
-            that.load();
-          });
-        }
-      }));
-      options.push(R.createElement(SearchOption, {
+      options.unshift(R.createElement(SearchOption, {
         show: that.state.show,
         type: 'date',
         parent: that,
@@ -529,13 +497,63 @@ require([
           });
         }
       }));
+      options.unshift(R.createElement(SearchOption, {
+        show: that.state.show,
+        type: 'publication',
+        parent: that,
+        options: SortOptions,
+        labelPrefix: 'Sort: ',
+        value: that.state.sort_on,
+        onClick: function(val) {
+          that.setState({
+            sort_on: val
+          }, function(){
+            that.load();
+          });
+        }
+      }));
+      if(that.props.additionalSites.length > 0){
+        var current = this.props.currentSiteLabel || 'current site'
+        var items = [['', current]].concat(that.props.additionalSites.map(function(v){
+          return [v, v];
+        }));
+        options.unshift(R.createElement(SearchOption, {
+          show: that.state.show,
+          type: 'additionalSites',
+          options: items,
+          parent: that,
+          labelPrefix: 'Source: ',
+          value: that.state.searchSite,
+          onClick: function(val) {
+            var searchType = that.state.searchType;
+            var searchSite = false;
+            if (val === current) {
+              searchType = 'all';
+            } else {
+              searchSite = val
+            }
+            that.setState({
+              searchSite: searchSite,
+              page: 1,
+              searchType: searchType
+            }, function(){
+              that.load();
+            });
+          }
+        }));
+      }
 
-      return D.div({ className: 'search-options'}, [
-        D.ul({}, options)
-      ]);
+      console.log(that.state);
+      return D.div(
+        { className: 'search-options' },
+        [
+          ...(!!that.state.searchHelpText ? [D.p({},that.state.searchHelpText )] : []),
+          D.ul({}, options),
+        ]
+      );
     },
 
-    render: function(){
+    render: function () {
       return D.form({ id: "searchform", actionName: "@@search", role: "search",
                       className: "search-form" }, [
         D.div({ className: "search-input-group" }, [
@@ -578,17 +596,23 @@ require([
   }catch(e){}
 
   var el = document.getElementById('searchComponent');
-  var component = R.render(R.createElement(
-    SearchComponent, cutils.extend(JSON.parse(el.getAttribute('data-search')), {
-      SearchableText: getParameterByName('SearchableText') || '',
-      Subject: Subject,
-      'Subject:list': Subjectlist,
-      searchUrl: el.getAttribute('data-search-url'),
-      searchType: searchType,
-      page: page,
-      searchSite: searchSite,
-      path: path
-    })), el);
+  var component = R.render(
+    R.createElement(
+      SearchComponent,
+      cutils.extend(JSON.parse(el.getAttribute('data-search')), {
+        SearchableText: getParameterByName('SearchableText') || '',
+        searchHelpText: getParameterByName('searchHelpText') || '',
+        Subject: Subject,
+        'Subject:list': Subjectlist,
+        searchUrl: el.getAttribute('data-search-url'),
+        searchType: searchType,
+        page: page,
+        searchSite: searchSite,
+        path: path,
+      })
+    ),
+    el
+  );
 
   window.onpopstate = function(e){
     if(e.state){

--- a/castle/cms/static/components/search.js
+++ b/castle/cms/static/components/search.js
@@ -243,7 +243,6 @@ require([
         url: this.props.searchUrl,
         data: state
       }).done(function (data) {
-        console.log(data);
         that.props.Subject = undefined;
         that.props['Subject:list'] = undefined;
         that.setState(
@@ -371,9 +370,9 @@ require([
         item.searchSite = that.state.searchSite;
         results.push(R.createElement(SearchResult, item));
       });
-      return D.div({ id: "search-results-wrapper" }, [
-        D.div({ id: "search-results-bar" }, [
-          D.span({ id: "results-count" }, [
+      return D.div({ id: 'search-results-wrapper' }, [
+        D.div({ id: 'search-results-bar' }, [
+          D.span({ id: 'results-count' }, [
             'Page ',
             that.state.page,
             ' of ',
@@ -381,8 +380,8 @@ require([
             ' results'
           ])
         ]),
-        D.div({ id: "search-results" }, [
-          D.ul({ className: "searchResults" }, results),
+        D.div({ id: 'search-results' }, [
+          D.ul({ className: 'searchResults' }, results),
           this.renderPaging()
         ])
       ]);
@@ -543,7 +542,6 @@ require([
         }));
       }
 
-      console.log(that.state);
       return D.div(
         { className: 'search-options' },
         [
@@ -601,7 +599,7 @@ require([
       SearchComponent,
       cutils.extend(JSON.parse(el.getAttribute('data-search')), {
         SearchableText: getParameterByName('SearchableText') || '',
-        searchHelpText: getParameterByName('searchHelpText') || '',
+        searchHelpText: searchHelpText,
         Subject: Subject,
         'Subject:list': Subjectlist,
         searchUrl: el.getAttribute('data-search-url'),

--- a/castle/cms/static/less/misc/search.less
+++ b/castle/cms/static/less/misc/search.less
@@ -55,6 +55,10 @@
   border-top: 1px solid @border_color;
   border-bottom: 1px solid @border_color;
 
+  p {
+    margin-left: 22px;
+  }
+  
   > ul {
     position: relative;
     padding: 0;

--- a/castle/cms/upgrades.zcml
+++ b/castle/cms/upgrades.zcml
@@ -325,8 +325,25 @@
     title="Upgrade CastleCMS to 2.6.11"
     description=""
     source="*"
-    destination="2603"
+    destination="2611"
     handler=".upgrades.upgrade_2_6_11.upgrade"
     profile="castle.cms:default"/>
+  
+  <genericsetup:registerProfile
+    name="2_6_12"
+    title="CastleCMS upgrade to 2.6.12 profile"
+    directory="profiles/2_6_12"
+    description=""
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
+
+  <genericsetup:upgradeStep
+    title="Upgrade CastleCMS to 2.6.12"
+    description=""
+    source="*"
+    destination="2612"
+    handler=".upgrades.upgrade_2_6_12.upgrade"
+    profile="castle.cms:default"
+    />
 
 </configure>

--- a/castle/cms/upgrades/upgrade_2_6_12.py
+++ b/castle/cms/upgrades/upgrade_2_6_12.py
@@ -1,0 +1,10 @@
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.resources.browser.cook import cookWhenChangingSettings
+
+PROFILE_ID = 'profile-castle.cms:2_6_12'
+
+
+def upgrade(site, logger=None):
+    setup = getToolByName(site, 'portal_setup')
+    setup.runAllImportStepsFromProfile(PROFILE_ID)
+    cookWhenChangingSettings(site)


### PR DESCRIPTION
- added ability to add a configurable help line at the top of @@search page.
- fixed bug that showed results as "Result # of Page #"
- fixed bug that showed video filter twice
- moved Source:, Sort:, and When: tabs on search page to be on the left of the search page toolbar. This way, when the filters (Audio, Video, All, etc) appear and disappear after changing source, they don't move Source, Sort and When (which are always there)
- alphabetized filters on search page