### PR TITLE
fix QueryListingTile to split display_fields correctly when passed to…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 2.6.21 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- fix the QueryListingTile to split display_fields correctly when passed as
+  a query parameter to the @@castle.cms.querylisting view
 
 
 2.6.20 (2020-07-14)

--- a/castle/cms/tiles/querylisting.py
+++ b/castle/cms/tiles/querylisting.py
@@ -172,6 +172,14 @@ class QueryListingTile(BaseTile, DisplayTypeTileMixin):
         return parsed
 
     @property
+    def data(self):
+        if 'display_fields' in self.request.form:
+            if type(self.request.form['display_fields']) == str:
+                self.request.form['display_fields'] = self.request.form['display_fields'].split(',')
+        thedata = super(QueryListingTile, self).data
+        return thedata
+
+    @property
     def display_fields(self):
         df = self.data.get('display_fields', None)
         if df is None:

--- a/castle/cms/tiles/querylisting.py
+++ b/castle/cms/tiles/querylisting.py
@@ -175,7 +175,8 @@ class QueryListingTile(BaseTile, DisplayTypeTileMixin):
     def data(self):
         if 'display_fields' in self.request.form:
             if type(self.request.form['display_fields']) == str:
-                self.request.form['display_fields'] = self.request.form['display_fields'].split(',')
+                fields = self.request.form['display_fields'].split(',')
+                self.request.form['display_fields'] = [a.strip() for a in fields if len(a.strip()) > 0]
         thedata = super(QueryListingTile, self).data
         return thedata
 


### PR DESCRIPTION
… @@castle.cms.querylisting as a query string parameter