### PR TITLE
fix dashboard by manually updating modificationDate in metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ export/
 /package.json
 /watch-run.py
 /watchable-grunt.js
+.gitmodules

--- a/castle/cms/audit.py
+++ b/castle/cms/audit.py
@@ -7,29 +7,38 @@ from castle.cms.interfaces import ITrashed
 from castle.cms.utils import ESConnectionFactoryFactory
 from elasticsearch import TransportError
 from plone import api
-from plone.app.iterate.interfaces import (IAfterCheckinEvent,
-                                          ICancelCheckoutEvent, ICheckoutEvent,
-                                          IWorkingCopyDeletedEvent)
-from plone.registry.interfaces import (IRegistry,
-                                       IRecordAddedEvent,
-                                       IRecordRemovedEvent,
-                                       IRecordModifiedEvent)
+from plone.app.iterate.interfaces import (
+    IAfterCheckinEvent,
+    ICancelCheckoutEvent,
+    ICheckoutEvent,
+    IWorkingCopyDeletedEvent
+)
+from plone.registry.interfaces import (
+    IRegistry,
+    IRecordAddedEvent,
+    IRecordRemovedEvent,
+    IRecordModifiedEvent
+)
 from plone.uuid.interfaces import IUUID
 from Products.DCWorkflow.interfaces import IAfterTransitionEvent
-from Products.PluggableAuthService.interfaces.events import (ICredentialsUpdatedEvent,  # noqa
-                                                             IPrincipalCreatedEvent,  # noqa
-                                                             IPrincipalDeletedEvent,  # noqa
-                                                             IPropertiesUpdatedEvent,  # noqa
-                                                             IUserLoggedInEvent,  # noqa
-                                                             IUserLoggedOutEvent)  # noqa
+from Products.PluggableAuthService.interfaces.events import (
+    ICredentialsUpdatedEvent,
+    IPrincipalCreatedEvent,
+    IPrincipalDeletedEvent,
+    IPropertiesUpdatedEvent,
+    IUserLoggedInEvent,
+    IUserLoggedOutEvent,
+)
 from zope.component import ComponentLookupError, getUtility
 from zope.globalrequest import getRequest
 from zope.interface import providedBy
-from zope.lifecycleevent.interfaces import (IObjectAddedEvent,
-                                            IObjectCopiedEvent,
-                                            IObjectModifiedEvent,
-                                            IObjectMovedEvent,
-                                            IObjectRemovedEvent)
+from zope.lifecycleevent.interfaces import (
+    IObjectAddedEvent,
+    IObjectCopiedEvent,
+    IObjectModifiedEvent,
+    IObjectMovedEvent,
+    IObjectRemovedEvent
+)
 
 
 class DefaultRecorder(object):

--- a/castle/cms/browser/content/fc.py
+++ b/castle/cms/browser/content/fc.py
@@ -349,7 +349,7 @@ class FolderContentsView(BaseFolderContentsView):
         columns = super(FolderContentsView, self).get_columns()
         sm = getSecurityManager()
         if sm.checkPermission(DEFAULT_PERMISSION_SECURE, self.context):
-            # if has permission, add more more columns
+            # if has permission, add more columns
             columns.update({
                 'Creator': 'Creator',
                 'last_modified_by': 'Last modified by'

--- a/castle/cms/browser/templates/audit-inner.pt
+++ b/castle/cms/browser/templates/audit-inner.pt
@@ -93,7 +93,7 @@
             <span tal:condition="not: has_obj">${python: view.get_path(data)}</span>
           </td>
           <td>${user/getUserName|user/getId|data/user}</td>
-          <td>${data/summary}</td>
+          <td class="audit-summary">${data/summary}</td>
           <td class="pat-moment"
                  data-pat-moment="format:relative"
                  data-date="${data/date}Z">${data/date}</td>

--- a/castle/cms/static/less/public/print.less
+++ b/castle/cms/static/less/public/print.less
@@ -96,7 +96,10 @@
   header, nav, footer, #portal-searchbox, #portal-personaltools, #portal-breadcrumbs, .global-footer, #edit-bar {
     display: none;
   }
- .toolbar-initialized .wrap, body.castle-toolbar-active #visual-wrapper, body.template-folder_contents.castle-toolbar-active #main-content-container, body.template-theming-controlpanel.castle-toolbar-active {
+ .toolbar-initialized .wrap,
+ body.castle-toolbar-active #visual-wrapper,
+ body.template-folder_contents.castle-toolbar-active #main-content-container,
+ body.template-theming-controlpanel.castle-toolbar-active {
       margin: 5px !important;
       width: 100% !important;
       padding: 0px !important;

--- a/castle/cms/static/less/public/tables.less
+++ b/castle/cms/static/less/public/tables.less
@@ -74,6 +74,20 @@ th {
   .table {
     background-color: @body-bg;
   }
+
+  &.audit-results {
+    display: -ms-grid;
+    display: grid;
+    grid-template-columns:
+      repeat(3, minmax(80px, 1fr))
+      minmax(100px, auto)
+      minmax(80px , 1fr);
+    thead,
+    tbody,
+    tr {
+      display: contents;
+    }
+  }
 }
 
 

--- a/castle/cms/subscribers.py
+++ b/castle/cms/subscribers.py
@@ -30,7 +30,19 @@ except ImportError:
         pass
 
 
+def _update_modification_date(obj):
+    try:
+        workflow_history = obj.workflow_history['simple_publication_workflow']
+        final_index = len(workflow_history) - 1
+        modification_datetime = workflow_history[final_index]['time']
+        obj.setModificationDate(modification_datetime)
+        obj.reindexObject(idxs=['modified'])
+    except Exception:
+        return
+
+
 def on_content_state_changed(obj, event):
+    _update_modification_date(obj)
     obj.reindexObject(idxs=['has_private_parents'])
     if IFolderish.providedBy(obj):
         tasks.reindex_children.delay(obj, ['has_private_parents'])

--- a/castle/cms/toolbar.py
+++ b/castle/cms/toolbar.py
@@ -406,11 +406,10 @@ class Toolbar(BrowserView):
 
         actions = [x for x in self._get_portal_actions(name)]
 
-        if additional is not []:
-            # Include actions from the old default portal_actions to provide
-            # support for Plone 5 add-ons
-            for action in additional:
-                actions += [x for x in self._get_portal_actions(action)]
+        # Include actions from the old default portal_actions to provide
+        # support for Plone 5 add-ons
+        for action in additional:
+            actions += [x for x in self._get_portal_actions(action)]
 
         urlExpr = 'url_expr_object'
         conditionExpr = 'available_expr_object'


### PR DESCRIPTION
The issue seems to have been that last_modified_by metadata index was being updated, but modificationDate was not being updated for state changes, which was then, obviously, displaying weird mixes of correct and incorrect data in the dashboard. While there are many legitimate ways to fix this (the audit log works, so we could just call that and filter out info we don't care about), this seemed the most straightforward for now.