### PR TITLE
Added Makefile for easier development setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ env
 env2
 dump.rdb
 export/
-/Makefile
 /package.json
 /watch-run.py
 /watchable-grunt.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+.PHONY=help
+help:
+	@echo "available targets -->\n"
+	@cat Makefile | grep ".PHONY" | python -c 'import sys; sys.stdout.write("".join(list(map(lambda line: line.replace(".PHONY"+"=", "") if (".PHONY"+"=") in line else "", sys.stdin))))'
+
+.PHONY=clean
+clean:
+	if git status | grep -q "working tree clean"; then \
+		git clean -fdx; \
+	else \
+		git status; \
+		printf "\n\033[0;31mrefusing to \`make clean\` due to \`git status\` !\033[0m\n"; \
+		exit 1; \
+	fi
+
+.PHONY=fixdocker
+fixdocker:
+	docker-compose down
+	docker system prune -f
+	-docker kill $$(docker ps -q)
+
+.PHONY=env
+env:
+	if [ ! -d "./bin" ]; then \
+		virtualenv -p python2.7 .; \
+		bin/pip install --upgrade pip; \
+		bin/pip install -r requirements.txt; \
+		make buildout; \
+	fi
+
+.PHONY=buildout
+buildout: env
+	if [ -f "local.cfg" ]; then \
+		bin/buildout -c local.cfg; \
+	else \
+		bin/buildout; \
+	fi
+
+.PHONY=docker-compose
+docker-compose: env fixdocker
+	docker-compose up
+
+.PHONY=fg
+fg: env
+	bin/instance fg


### PR DESCRIPTION
I added a basic `Makefile` to make first time setup and development easier.

* The default target is `help` which just displays a list of available `PHONY` targets.
* The `clean` target runs `git clean -fdx` if `git status` has `working tree clean`
* The `fixdocker` target kills all docker services and runs `docker system prune -f`
* The `env` target sets up the python virtual environment and runs buildout (if it isn't already set up)
* The `buildout` target runs buildout with the appropriate config
* The `docker-compose` target is the same as `make env fixdocker && docker-compose up`
* The `fg` target is the same as `make env && bin/instance fg`