### PR TITLE
Bd/related items exclude unpublished

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.0b1 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Implement functionality to hide related resource from being displayed for
+  unpublished content
 
 
 3.0.0b0 (2021-04-30)

--- a/castle/cms/browser/viewlets/configure.zcml
+++ b/castle/cms/browser/viewlets/configure.zcml
@@ -23,6 +23,16 @@
       layer="castle.cms.interfaces.ICastleLayer"
       template="social_tags_body.pt"
       />
+
+    <browser:viewlet
+      name="plone.belowcontentbody.relateditems"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentBody"
+      for="plone.app.relationfield.behavior.IRelatedItems"
+      class="castle.cms.browser.viewlets.relateditems.ContentRelatedItems"
+      permission="zope2.View"
+      layer="castle.cms.interfaces.ICastleLayer"
+      />
+
   </configure>
 
 </configure>

--- a/castle/cms/browser/viewlets/relateditems.py
+++ b/castle/cms/browser/viewlets/relateditems.py
@@ -18,7 +18,7 @@ class ContentRelatedItems(BaseContentRelatedItems):
             # the query will return an empty list if the user
             # has no permission to see the target object
             catalog_args = {
-                'path': dict(query=path, depth=0), 
+                'path': dict(query=path, depth=0),
             }
             if not api.portal.get_registry_record(
                 'plone.display_unpublished_related_items',

--- a/castle/cms/browser/viewlets/relateditems.py
+++ b/castle/cms/browser/viewlets/relateditems.py
@@ -1,0 +1,31 @@
+from plone.app.layout.viewlets.content import ContentRelatedItems as BaseContentRelatedItems
+from Products.CMFCore.utils import getToolByName
+from plone import api
+
+
+class ContentRelatedItems(BaseContentRelatedItems):
+
+    # override this method to respect castle.display_unpublished_related_items registry setting
+    def related2brains(self, related):
+        catalog = getToolByName(self.context, "portal_catalog")
+        brains = []
+        for r in related:
+            path = r.to_path
+            if path is None:
+                # Item was deleted.  The related item should have been cleaned
+                # up, but apparently this does not happen.
+                continue
+            # the query will return an empty list if the user
+            # has no permission to see the target object
+            catalog_args = {
+                'path': dict(query=path, depth=0), 
+            }
+            if not api.portal.get_registry_record(
+                'plone.display_unpublished_related_items',
+                default=False,
+            ):
+                catalog_args['review_state'] = 'published'
+            brains.extend(
+                catalog(**catalog_args)
+            )
+        return brains

--- a/castle/cms/interfaces/controlpanel.py
+++ b/castle/cms/interfaces/controlpanel.py
@@ -213,6 +213,14 @@ class ISecuritySchema(controlpanel.ISecuritySchema):
         default=False,
         required=False)
 
+    display_unpublished_related_items = schema.Bool(
+        title=u'Display unpublished related items',
+        description=u'Check this box to allow Related Items that are not currently published '
+                    u'to be displayed when viewing content containing related items.',
+        default=False,
+        required=False,
+    )
+
 
 class IAnnouncementData(Interface):
     show_announcement = schema.Bool(

--- a/castle/cms/profiles/3_0_00/metadata.xml
+++ b/castle/cms/profiles/3_0_00/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>3000</version>
+</metadata>

--- a/castle/cms/profiles/3_0_00/registry.xml
+++ b/castle/cms/profiles/3_0_00/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+
+  <record
+    name="plone.display_unpublished_related_items"
+    interface="castle.cms.interfaces.ISecuritySchema"
+    field="display_unpublished_related_items"
+  >
+    <value>False</value>
+  </record>
+</registry>

--- a/castle/cms/profiles/default/metadata.xml
+++ b/castle/cms/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2631</version>
+  <version>3000</version>
   <dependencies>
     <dependency>profile-plone.app.querystring:default</dependency>
     <dependency>profile-plone.app.mosaic:default</dependency>

--- a/castle/cms/upgrades.zcml
+++ b/castle/cms/upgrades.zcml
@@ -441,7 +441,7 @@
 
   <genericsetup:upgradeStep
     title="Upgrade CastleCMS to 2.6.30"
-    description="changes default slideshow view to the actual slideshow"
+    description="2630 changes default slideshow view to the actual slideshow"
     source="*"
     destination="2630"
     handler=".upgrades.upgrade_2_6_30"
@@ -458,10 +458,28 @@
 
   <genericsetup:upgradeStep
     title="Upgrade CastleCMS to 2.6.31"
-    description="adds/ fixes some mockup-structure pagination functionality"
+    description="2631 adds/ fixes some mockup-structure pagination functionality"
     source="*"
     destination="2631"
     handler=".upgrades.upgrade_2_6_31"
     profile="castle.cms:default"
     />
+
+  <genericsetup:registerProfile
+    name="3_0_00"
+    title="CastleCMS upgrade to 3.0.0 profile"
+    directory="profiles/3_0_00"
+    description=""
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
+
+  <genericsetup:upgradeStep
+    title="Upgrade CastleCMS to 3.0.0"
+    description="3000 adds the functionality to filter out unpublished related items"
+    source="*"
+    destination="3000"
+    handler=".upgrades.upgrade_3_0_00"
+    profile="castle.cms:default"
+    />
+
 </configure>

--- a/castle/cms/upgrades/__init__.py
+++ b/castle/cms/upgrades/__init__.py
@@ -68,3 +68,5 @@ upgrade_2_6_25 = default_upgrade_factory('2_6_25')
 upgrade_2_6_27 = default_upgrade_factory('2_6_27')
 upgrade_2_6_30 = default_upgrade_factory('2_6_30')
 upgrade_2_6_31 = default_upgrade_factory('2_6_31')
+
+upgrade_3_0_00 = default_upgrade_factory('3_0_00')

--- a/docs/controlpanel.rst
+++ b/docs/controlpanel.rst
@@ -136,3 +136,12 @@ The can be configured on the environment with these environment settings:
 
 (you can also provide twitter auth key and secret through control panel; however,
 in the future, these will all be environment variables)
+
+
+Security Settings
+-----------------
+
+in /@@security-controlpanel, you can change settings for the way some content shows
+up. For example, `Allow access to published objects inside private containers` and
+`Display unpublished related items` settings can be changed there. (Both of these
+values default to False)


### PR DESCRIPTION
this pr provides a controlpanel registry setting plone.display_unpublished_related_items (very similar to Allow access to published objects inside private containers), which controls whether related items should be visible if they're not published. Defaults to false.