### PR TITLE
Add auto-publish/auto-retract cron script

### DIFF
--- a/castle/cms/cron/_auto_publish_retract.py
+++ b/castle/cms/cron/_auto_publish_retract.py
@@ -1,0 +1,78 @@
+
+from DateTime import DateTime
+from plone import api
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from tendo import singleton
+from zope.component.hooks import setSite
+
+import logging
+import transaction
+
+
+logger = logging.getLogger('castle.cms')
+
+
+def run_query(query_params):
+
+    catalog = api.portal.get_tool('portal_catalog')
+    content = catalog(**query_params)
+    
+    to_state = 'published' if query_params.get('effective') else 'private'
+    for brain in content:
+        obj = brain.getObject()
+        api.content.transition(
+            obj=obj, 
+            to_state=to_state
+        )
+        obj.setModificationDate()
+        obj.reindexObject(idxs=['modified'])
+    transaction.commit()
+
+
+def set_queries(site):
+    setSite(site)
+    
+    # XXX: Needed to run locally, probably not necessary for live environment
+    # from AccessControl.SecurityManagement import newSecurityManager
+    # admin = api.user.get(username='admin')
+    # newSecurityManager(None, admin)
+
+    # publish pending content with an effective date within 30 minutes of cron run
+    start = DateTime() - (30.0 / (24 * 60))
+    end = DateTime()
+    publish_query = {
+        'effective': {
+            'query': (start, end),
+            'range': 'min:max'
+        },
+        'review_state': ['pending', 'private'],
+        'sort_on': 'modified',
+        'sort_order': 'reverse'
+    }
+    run_query(publish_query)
+
+    # retract published content with an expiration date older than cron run
+    retract_query = {
+        'expires': {
+            'query': DateTime(),
+            'range': 'max'
+        },
+        'review_state': 'published'
+    }
+    run_query(retract_query)
+
+
+def run(app):
+    singleton.SingleInstance('autopublish')
+
+    for oid in app.objectIds():  # noqa
+        obj = app[oid]  # noqa
+        if IPloneSiteRoot.providedBy(obj):
+            try:
+                set_queries(obj)
+            except Exception:
+                logger.error('Could not update content for %s' % oid, exc_info=True)
+
+
+if __name__ == '__main__':
+    run(app)  # noqa


### PR DESCRIPTION
This script auto-publishes and retracts content based on specified dates in the 'Dates' tab.

It is assumed that this cron job will run every 30 minutes, as dates can be specified in 30-minute intervals.

The 'admin' user needed to be set to query private documents locally, this can probably be removed.