### PR TITLE
Fix mass copy/paste async task

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changelog
 3.0.0b130 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Fix mass copy/paste functionality
 
 
 3.0.0b129 (2023-12-07)

--- a/castle/cms/tasks/content.py
+++ b/castle/cms/tasks/content.py
@@ -42,11 +42,8 @@ def paste_error_handle(where, op, mdatas):
 def _paste_items(where, op, mdatas):
     logger.info('Copying a bunch of items')
     portal = api.portal.get()
-    catalog = api.portal.get_tool('portal_catalog')
     dest = portal.restrictedTraverse(str(where.lstrip('/')))
 
-    count = 0
-    commit_count = 0
     if not getCelery().conf.task_always_eager:
         portal._p_jar.sync()
 
@@ -58,7 +55,6 @@ def _paste_items(where, op, mdatas):
         pass
 
     for mdata in mdatas[:]:
-        count += len(catalog(path={'query': '/'.join(mdata), 'depth': -1}))
         ob = portal.unrestrictedTraverse(str('/'.join(mdata)), None)
         if ob is None:
             continue

--- a/castle/cms/tasks/content.py
+++ b/castle/cms/tasks/content.py
@@ -68,18 +68,6 @@ def _paste_items(where, op, mdatas):
         else:
             api.content.move(ob, dest, safe_id=True)
 
-        if count / 50 != commit_count:
-            # commit every 50 objects moved
-            transaction.commit()
-            commit_count = count / 50
-            if not getCelery().conf.task_always_eager:
-                portal._p_jar.sync()
-            # so we do not redo it
-            try:
-                mdatas.remove(mdata)
-            except Exception:
-                pass
-
     # we commit here so we can trigger conflict errors before
     # trying to send email
     transaction.commit()


### PR DESCRIPTION
The mass paste task wasn't working due to some batching logic - the idea was to commit a transaction for every 50 documents moved. However, about every other commit threw a Zope 'ConflictError', and after the third batch the process would quit and nothing would be committed.

I tried a few of the built-in Zope solutions for avoiding transaction conflicts (transaction managers, the 'attempts' mechanism to retry transactions, etc) but none of these could circumvent the error. The ZODB docs highly discourage the developer from trying to take conflict resolution into their own hands, so I ultimately decided to just remove the logic entirely (as it was not present in the mass delete task).

I tested the task by pasting up to around 2000 documents and everything works fine  - no conflict errors arise.