### PR TITLE
fix newly introduced bug that prevented Videos from adapting IPrimary…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changelog
 3.1.0b4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- fix newly introduced bug that prevented Videos from adapting IPrimaryField
 
 
 3.1.0b3 (2025-03-03)

--- a/castle/cms/interfaces/content.py
+++ b/castle/cms/interfaces/content.py
@@ -5,9 +5,11 @@ from plone.app.textfield import RichText
 from plone.autoform import directives
 from plone.namedfile.field import NamedBlobFile
 from plone.namedfile.interfaces import INamedImage
+from plone.rfc822.interfaces import IPrimaryField
 from plone.supermodel import model
 from Products.CMFPlone.interfaces import IHideFromBreadcrumbs
 from zope.interface import (
+    alsoProvides,
     Attribute,
     Interface,
     Invalid,
@@ -86,6 +88,7 @@ class IVideo(IMedia):
                     u'Please try to upload again.'
                 ).format(getattr(data.file, 'filename', ''))
                 raise Invalid(error_message)
+alsoProvides(IVideo['file'], IPrimaryField)
 
 
 class IAudio(IMedia):


### PR DESCRIPTION
…Field

Context:

Explain general plone issue:
https://community.plone.org/t/objects-can-no-longer-adapt-to-iprimaryfieldinfo/2597/3

a bug specifically introduced into castle.cms here:
https://github.com/castlecms/castle.cms/commit/9a76b044fd057078cae34bc91bf19d91ba77bf44#diff-06fb6e9782b033ad7719dd98b4aca3304aa2ef6473022887f3e570c6a9b33825R46

it did not account for previous "marshal-primary=true" as shown here:
https://github.com/castlecms/castle.cms/blob/master/castle/cms/schema/video.xml#L13

explained solution: 
>>> from plone.rfc822.interfaces import IPrimaryField
>>> schema = model.schema
>>> IPrimaryField.providedBy(schema['title'])
False
>>> IPrimaryField.providedBy(schema['body'])
True
from here: https://github.com/plone/plone.rfc822/blob/master/plone/rfc822/supermodel.rst

tested locally. without fix: 
TypeError('Could not adapt', <Video at xxxxxxx.mp4>, <InterfaceClass plone.rfc822.interfaces.IPrimaryFieldInfo>)

with fix and no other changes:
File downloads as expected
